### PR TITLE
POC: feat: add support for parsing optional properties

### DIFF
--- a/src/AST.ts
+++ b/src/AST.ts
@@ -503,6 +503,7 @@ export interface PropertySignature extends Annotated {
   readonly type: AST
   readonly isOptional: boolean
   readonly isReadonly: boolean
+  readonly parseOptional: boolean
 }
 
 /**
@@ -513,8 +514,9 @@ export const createPropertySignature = (
   type: AST,
   isOptional: boolean,
   isReadonly: boolean,
+  parseOptional = false,
   annotations: Annotated["annotations"] = {}
-): PropertySignature => ({ name, type, isOptional, isReadonly, annotations })
+): PropertySignature => ({ name, type, isOptional, isReadonly, parseOptional, annotations })
 
 /**
  * @since 1.0.0
@@ -842,7 +844,14 @@ export const partial = (ast: AST): AST => {
     case "TypeLiteral":
       return createTypeLiteral(
         ast.propertySignatures.map((f) =>
-          createPropertySignature(f.name, f.type, true, f.isReadonly, f.annotations)
+          createPropertySignature(
+            f.name,
+            f.type,
+            true,
+            f.isReadonly,
+            f.parseOptional,
+            f.annotations
+          )
         ),
         ast.indexSignatures
       )

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -307,7 +307,7 @@ const parserFor = <A>(
               const parser = propertySignaturesTypes[i]
               const name = ps.name
               expectedKeys[name] = null
-              if (!Object.prototype.hasOwnProperty.call(input, name)) {
+              if (!Object.prototype.hasOwnProperty.call(input, name) && !ps.parseOptional) {
                 if (!ps.isOptional) {
                   const e = PR.key(name, [PR.missing])
                   if (allErrors) {

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -499,6 +499,12 @@ export interface OptionalSchema<A> {
 export const optional: <A>(schema: Schema<A>) => OptionalSchema<A> = I.optional
 
 /**
+ * @category combinators
+ * @since 1.0.0
+ */
+export const parseOptional: <A>(schema: Schema<A>) => Schema<A> = I.parseOptional
+
+/**
  * @since 1.0.0
  */
 export type OptionalKeys<T> = {

--- a/src/data/Option.ts
+++ b/src/data/Option.ts
@@ -85,3 +85,13 @@ export const parseNullable = <A>(value: Schema<A>): Schema<Option<A>> =>
     I.union(I._undefined, I.nullable(value)),
     I.transform(option(value), O.fromNullable, O.getOrNull)
   )
+
+/**
+ * @since 1.0.0
+ */
+export const optionFromOptional = <A>(value: Schema<A>): Schema<Option<A>> =>
+  pipe(
+    value,
+    parseNullable,
+    I.parseOptional
+  )

--- a/src/internal/common.ts
+++ b/src/internal/common.ts
@@ -214,10 +214,21 @@ const OptionalSchemaId = Symbol.for("@effect/schema/Schema/OptionalSchema")
 const isOptionalSchema = <A>(schema: object): schema is S.OptionalSchema<A> =>
   schema["_id"] === OptionalSchemaId
 
+const ParseOptionalSchemaId = Symbol.for("@effect/schema/Schema/ParseOptionalSchema")
+
+const isParseOptionalSchema = (schema: object): boolean => schema["_id"] === ParseOptionalSchemaId
+
 /** @internal */
 export const optional = <A>(schema: S.Schema<A>): S.OptionalSchema<A> => {
   const out: any = makeSchema(schema.ast)
   out["_id"] = OptionalSchemaId
+  return out
+}
+
+/** @internal */
+export const parseOptional = <A>(schema: S.Schema<A>): S.Schema<A> => {
+  const out: any = makeSchema(schema.ast)
+  out["_id"] = ParseOptionalSchemaId
   return out
 }
 
@@ -234,14 +245,17 @@ export const struct = <
 > =>
   makeSchema(
     AST.createTypeLiteral(
-      Reflect.ownKeys(fields).map((key) =>
-        AST.createPropertySignature(
+      Reflect.ownKeys(fields).map((key) => {
+        const isParseOptional = isParseOptionalSchema(fields[key])
+        const isOptional = isParseOptional || isOptionalSchema(fields[key])
+        return AST.createPropertySignature(
           key,
           (fields[key] as any).ast,
-          isOptionalSchema(fields[key]),
-          true
+          isOptional,
+          true,
+          isParseOptional
         )
-      ),
+      }),
       []
     )
   )

--- a/test/compiler/TypeScript.ts
+++ b/test/compiler/TypeScript.ts
@@ -839,7 +839,7 @@ describe.concurrent("TypeScript", () => {
     it("property signatures", () => {
       const schema = S.make(AST.createTypeLiteral(
         [
-          AST.createPropertySignature("a", AST.stringKeyword, false, true, {
+          AST.createPropertySignature("a", AST.stringKeyword, false, true, false, {
             [annotations.DocumentationId]: "description"
           })
         ],

--- a/test/data/Option.ts
+++ b/test/data/Option.ts
@@ -70,4 +70,20 @@ describe.concurrent("Option", () => {
     Util.expectEncodingSuccess(schema, O.none(), null)
     Util.expectEncodingSuccess(schema, O.some(1), "1")
   })
+
+  it("optionFromOptional. Decoder", () => {
+    const schema = S.struct({
+      a: _.optionFromOptional(S.number)
+    })
+    Util.expectDecodingSuccess(schema, {}, { a: O.none() })
+    Util.expectDecodingSuccess(schema, { a: 1 }, { a: O.some(1) })
+  })
+
+  it("optionFromOptional. Encoder", () => {
+    const schema = S.struct({
+      a: _.optionFromOptional(S.number)
+    })
+    Util.expectEncodingSuccess(schema, { a: O.none() }, { a: null })
+    Util.expectEncodingSuccess(schema, { a: O.some(1) }, { a: 1 })
+  })
 })


### PR DESCRIPTION
Adds support for parsing optional properties in TypeLiterals. This would enable support for schemas such as `optionFromOptional`, which I have included here.