### PR TITLE
changes documentation example for transformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1023,7 +1023,7 @@ const decode = (s: string): PR.ParseResult<boolean> =>
     : s === "false"
     ? PR.success(false)
     : PR.failure(
-        PR.type(AST.union([AST.literal("true"), AST.literal("false")]), s)
+        PR.type(AST.createUnion([AST.createLiteral("true"), AST.createLiteral("false")]), s)
       );
 
 // define a function that converts a boolean into a string


### PR DESCRIPTION
AST doesn't expose Union or Literal for me. It exposes createUnion or createLiteral. Therefore, this change proposes to change the example accordingly.