### PR TITLE
feat: added S.required combinator

### DIFF
--- a/.changeset/tricky-rockets-drop.md
+++ b/.changeset/tricky-rockets-drop.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Schema: added S.required

--- a/README.md
+++ b/README.md
@@ -866,6 +866,13 @@ pipe(S.struct({ a: S.string, b: S.number }), S.omit("a"));
 S.partial(S.struct({ a: S.string, b: S.number }));
 ```
 
+## Required
+
+```ts
+// $ExpectType Schema<Required<{ readonly a?: string; readonly b?: number; }>>
+S.required(S.struct({ a: S.optional(S.string), b: S.optional(S.number) }));
+```
+
 ## Records
 
 ### String keys

--- a/dtslint/ts4.7/Schema.ts
+++ b/dtslint/ts4.7/Schema.ts
@@ -280,6 +280,16 @@ S.partial(S.struct({ a: S.string,  b: S.number }));
 S.partial(S.struct({ a: S.string,  b: NumberFromString }));
 
 // ---------------------------------------------
+// Required
+// ---------------------------------------------
+
+// $ExpectType Schema<Required<{ readonly a: string; readonly b: number; }>, Required<{ readonly a: string; readonly b: number; }>>
+S.required(S.struct({ a: S.optional(S.string),  b: S.optional(S.number) }));
+
+// $ExpectType Schema<Required<{ readonly a: string; readonly b: string; }>, Required<{ readonly a: string; readonly b: number; }>>
+S.required(S.struct({ a: S.optional(S.string),  b: NumberFromString }));
+
+// ---------------------------------------------
 // Records
 // ---------------------------------------------
 

--- a/src/AST.ts
+++ b/src/AST.ts
@@ -1028,6 +1028,56 @@ export const partial = (ast: AST): AST => {
   }
 }
 
+/**
+ * Equivalent at runtime to the built-in TypeScript utility type `Required`.
+ *
+ * @since 1.0.0
+ */
+export const required = (ast: AST): AST => {
+  switch (ast._tag) {
+    case "Tuple": {
+      const restElement = pipe(
+        ast.rest,
+        O.map((rest) => createUnion(rest))
+      )
+
+      return createTuple(
+        [
+          ...ast.elements.map((e) => createElement(e.type, false)),
+          ...(O.isSome(restElement) ? [createElement(restElement.value, false)] : [])
+        ],
+        pipe(
+          ast.rest,
+          O.map((rest) => [createUnion(rest)])
+        ),
+        ast.isReadonly
+      )
+    }
+    case "TypeLiteral":
+      return createTypeLiteral(
+        ast.propertySignatures.map((f) =>
+          createPropertySignature(
+            f.name,
+            f.type,
+            false,
+            f.isReadonly,
+            f.annotations
+          )
+        ),
+        ast.indexSignatures
+      )
+    case "Union":
+      return createUnion(ast.types.map((member) => required(member)))
+    case "Lazy":
+      return createLazy(() => required(ast.f()))
+    case "Refinement":
+    case "Transform":
+      return required(ast.to)
+    default:
+      return ast
+  }
+}
+
 // -------------------------------------------------------------------------------------
 // compiler harness
 // -------------------------------------------------------------------------------------

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -612,6 +612,13 @@ export const partial = <I, A>(self: Schema<I, A>): Schema<Partial<I>, Partial<A>
  * @category combinators
  * @since 1.0.0
  */
+export const required = <I, A>(self: Schema<I, A>): Schema<Required<I>, Required<A>> =>
+  make(AST.required(self.ast))
+
+/**
+ * @category combinators
+ * @since 1.0.0
+ */
 export const record = <K extends string | symbol, I, A>(
   key: Schema<K>,
   value: Schema<I, A>

--- a/test/AST.ts
+++ b/test/AST.ts
@@ -262,6 +262,71 @@ describe.concurrent("AST", () => {
     )
   })
 
+  it("required/refinement", () => {
+    const schema = pipe(
+      S.struct({ a: S.optional(S.string), b: S.optional(S.string) }),
+      S.filter(({ a, b }) => a === b),
+      S.required
+    )
+    expect(schema.ast).toEqual(S.struct({ a: S.string, b: S.string }).ast)
+  })
+
+  it("required/transform", () => {
+    const schema = pipe(
+      S.string,
+      S.transform(S.struct({ a: S.optional(S.string) }), (a) => ({ a }), ({ a }) => a || ""),
+      S.required
+    )
+    expect(schema.ast).toEqual(S.struct({ a: S.string }).ast)
+  })
+
+  it("required/tuple/ e", () => {
+    // type A = [string]
+    // type B = Required<A>
+    const tuple = AST.createTuple([AST.createElement(AST.stringKeyword, false)], O.none(), true)
+    expect(AST.required(tuple)).toEqual(
+      AST.createTuple([AST.createElement(AST.stringKeyword, false)], O.none(), true)
+    )
+  })
+
+  it("required/tuple/ e + r", () => {
+    // type A = readonly [string, ...Array<number>]
+    // type B = Required<A>
+    const tuple = AST.createTuple(
+      [AST.createElement(AST.stringKeyword, false)],
+      O.some([AST.numberKeyword]),
+      true
+    )
+    expect(AST.required(tuple)).toEqual(
+      AST.createTuple(
+        [AST.createElement(AST.stringKeyword, false), AST.createElement(AST.numberKeyword, false)],
+        O.some([AST.createUnion([AST.numberKeyword])]),
+        true
+      )
+    )
+  })
+
+  it("required/tuple/ e + r + e", () => {
+    // type A = readonly [string, ...Array<number>, boolean]
+    // type B = Required<A> // [string, ...(number | boolean)[], number | boolean]
+    const tuple = AST.createTuple(
+      [AST.createElement(AST.stringKeyword, false)],
+      O.some([AST.numberKeyword, AST.booleanKeyword]),
+      true
+    )
+
+    expect(AST.required(tuple)).toEqual(
+      AST.createTuple(
+        [
+          AST.createElement(AST.stringKeyword, false),
+          AST.createElement(AST.createUnion([AST.numberKeyword, AST.booleanKeyword]), false)
+        ],
+        O.some([AST.createUnion([AST.numberKeyword, AST.booleanKeyword])]),
+        true
+      )
+    )
+  })
+
   it("appendRestElement/ should add a rest element", () => {
     const tuple = AST.createTuple([AST.createElement(AST.stringKeyword, false)], O.none(), true)
     const actual = AST.appendRestElement(tuple, AST.numberKeyword)

--- a/test/Schema.ts
+++ b/test/Schema.ts
@@ -4,6 +4,7 @@ import * as O from "@effect/data/Option"
 import * as AST from "@effect/schema/AST"
 import * as P from "@effect/schema/Parser"
 import * as S from "@effect/schema/Schema"
+import { expectParseFailure, expectParseSuccess } from "@effect/schema/test/util"
 
 describe.concurrent("Schema", () => {
   it("exports", () => {
@@ -56,6 +57,63 @@ describe.concurrent("Schema", () => {
     expect(S.decodePromise).exist
     expect(S.validatePromise).exist
     expect(S.encodePromise).exist
+
+    expect(S.partial).exist
+    expect(S.required).exist
+  })
+
+  it("required/ struct", () => {
+    const schema = S.required(S.struct({ a: S.optional(S.number) }))
+
+    expectParseSuccess(schema, { a: 1 }, { a: 1 })
+    expectParseFailure(schema, {}, "/a is missing")
+  })
+
+  it("required/ filter", () => {
+    const schema = S.required(S.struct({
+      a: S.optional(pipe(S.number, S.greaterThan(0)))
+    }))
+
+    expectParseSuccess(schema, { a: 1 }, { a: 1 })
+    expectParseFailure(schema, {}, "/a is missing")
+  })
+
+  it("partial/ filter", () => {
+    const schema = S.partial(S.struct({
+      a: pipe(S.number, S.greaterThan(0))
+    }))
+
+    expectParseSuccess(schema, { a: 1 }, { a: 1 })
+    expectParseSuccess(schema, {}, {})
+  })
+
+  it("required/ deep struct", () => {
+    const schema = S.required(S.struct({ c: S.struct({ d: S.optional(S.number) }) }))
+
+    expectParseSuccess(schema, { c: { d: 1 } }, { c: { d: 1 } })
+    expectParseFailure(schema, {}, "/c is missing")
+  })
+
+  it("required/ tuple", () => {
+    const schema = S.required(pipe(S.tuple(S.number), S.optionalElement(S.string)))
+
+    expectParseSuccess(schema, [0, ""], [0, ""])
+    expectParseFailure(schema, [0], "/1 is missing")
+  })
+
+  it("required/tuple/ e + r + e", () => {
+    // type A = readonly [string, ...Array<number>, boolean]
+    // type B = Required<A> // [string, ...(number | boolean)[], number | boolean]
+
+    const s_ = pipe(S.tuple(S.string), S.rest(S.number), S.element(S.boolean))
+    const schema = S.required(s_)
+
+    expectParseFailure(schema, [], "/0 is missing")
+    expectParseFailure(schema, [""], "/1 is missing")
+    expectParseSuccess(schema, ["", 0], ["", 0])
+    expectParseSuccess(schema, ["", true], ["", true])
+    expectParseSuccess(schema, ["", true, 0], ["", true, 0])
+    expectParseSuccess(schema, ["", 0, true], ["", 0, true])
   })
 
   it("brand/ annotations", () => {


### PR DESCRIPTION
Adds S.required

```js
const schema = S.required(S.struct({ a: S.optional(S.number) }))

expectParseSuccess(schema, { a: 1 }, { a: 1 })
expectParseFailure(schema, {}, "/a is missing")
```

https://github.com/colinhacks/zod#required