### PR TITLE
fix: align dateFromString with numberFromString

### DIFF
--- a/.changeset/flat-squids-exist.md
+++ b/.changeset/flat-squids-exist.md
@@ -1,5 +1,5 @@
 ---
-"@effect/schema": patch
+"@effect/schema": minor
 ---
 
 aligns usage of dateFromString with numberFromString

--- a/.changeset/flat-squids-exist.md
+++ b/.changeset/flat-squids-exist.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+aligns usage of dateFromString with numberFromString

--- a/README.md
+++ b/README.md
@@ -1162,7 +1162,7 @@ Transforms a `string` into a `Date` by parsing the string using `Date.parse`.
 import * as S from "@effect/schema/Schema";
 
 // const schema: S.Schema<string, Date>
-const schema = S.dateFromString;
+const schema = S.dateFromString(S.string);
 const parse = S.parse(schema);
 
 parse("1970-01-01T00:00:00.000Z"); // new Date(0)

--- a/docs/modules/Schema.ts.md
+++ b/docs/modules/Schema.ts.md
@@ -1096,7 +1096,7 @@ Transforms a `string` into a `Date` by parsing the string using `Date.parse`.
 **Signature**
 
 ```ts
-export declare const dateFromString: Schema<string, Date>
+export declare const dateFromString: <I>(self: Schema<I, string>) => Schema<I, date>
 ```
 
 Added in v1.0.0

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -1423,17 +1423,20 @@ export const date: Schema<Date> = declare(
   @category date
   @since 1.0.0
 */
-export const dateFromString: Schema<string, Date> = transformResult(
-  string,
-  date,
-  (s) => {
-    const n = Date.parse(s)
-    return isNaN(n)
-      ? PR.failure(PR.type(dateFromString.ast, s))
-      : PR.success(new Date(n))
-  },
-  (n) => PR.success(n.toISOString())
-)
+export const dateFromString = <I>(self: Schema<I, string>): Schema<I, Date> => {
+  const schema: Schema<I, Date> = transformResult(
+    self,
+    date,
+    (s) => {
+      const n = Date.parse(s)
+      return isNaN(n)
+        ? PR.failure(PR.type(schema.ast, s))
+        : PR.success(new Date(n))
+    },
+    (n) => PR.success(n.toISOString())
+  )
+  return schema
+}
 
 // ---------------------------------------------
 // data/Either

--- a/test/data/Date.ts
+++ b/test/data/Date.ts
@@ -36,7 +36,7 @@ describe.concurrent("Date", () => {
   })
 
   describe.concurrent("dateFromString", () => {
-    const schema = S.dateFromString
+    const schema = S.dateFromString(S.string)
 
     it("property tests", () => {
       Util.roundtrip(schema)
@@ -65,7 +65,7 @@ describe.concurrent("Date", () => {
     })
 
     it("example", async () => {
-      const schema = S.dateFromString
+      const schema = S.dateFromString(S.string)
 
       // success cases
       await Util.expectParseSuccess(schema, "0", new Date("0"))


### PR DESCRIPTION
Currently numberFromString returns a function returning a Schema while dateFromString just returns a Schema. Limitation on the latter being that you can't enforce limitations such as string size of the input string.