### PR TITLE
Add ulid schema

### DIFF
--- a/.changeset/cold-masks-sit.md
+++ b/.changeset/cold-masks-sit.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": minor
+---
+
+Add schema for [ULID](https://github.com/ulid/spec)

--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ S.never;
 
 S.json;
 S.UUID;
+S.ULID;
 ```
 
 ## Literals

--- a/docs/modules/Schema.ts.md
+++ b/docs/modules/Schema.ts.md
@@ -80,6 +80,7 @@ Added in v1.0.0
 - [constructors](#constructors)
   - [JsonNumber](#jsonnumber)
   - [UUID](#uuid)
+  - [ULID](#ulid)
   - [chunkFromSelf](#chunkfromself)
   - [enums](#enums)
   - [instanceOf](#instanceof)
@@ -129,7 +130,7 @@ Added in v1.0.0
   - [nonNaN](#nonnan)
   - [nonNegative](#nonnegative)
   - [nonPositive](#nonpositive)
-  - [numberFromString](#numberfromstring)
+  - [numberFromString](#numberfromstring-1)
   - [positive](#positive)
 - [option](#option-1)
   - [optionFromNullable](#optionfromnullable)
@@ -163,7 +164,7 @@ Added in v1.0.0
   - [nonEmpty](#nonempty)
   - [pattern](#pattern)
   - [startsWith](#startswith)
-  - [trim](#trim)
+  - [trim](#trim-1)
   - [trimmed](#trimmed)
 - [type id](#type-id)
   - [BetweenBigintTypeId](#betweenbiginttypeid)
@@ -202,6 +203,7 @@ Added in v1.0.0
   - [StartsWithTypeId](#startswithtypeid)
   - [TrimmedTypeId](#trimmedtypeid)
   - [UUIDTypeId](#uuidtypeid)
+  - [ULIDTypeId](#ulidtypeid)
   - [ValidDateTypeId](#validdatetypeid)
 - [utils](#utils)
   - [FromOptionalKeys (type alias)](#fromoptionalkeys-type-alias)
@@ -1074,6 +1076,16 @@ Added in v1.0.0
 
 ```ts
 export declare const UUID: Schema<string, string>
+```
+
+Added in v1.0.0
+
+## ULID
+
+**Signature**
+
+```ts
+export declare const ULID: Schema<string, string>
 ```
 
 Added in v1.0.0
@@ -2363,6 +2375,16 @@ Added in v1.0.0
 
 ```ts
 export declare const UUIDTypeId: '@effect/schema/UUIDTypeId'
+```
+
+Added in v1.0.0
+
+## ULIDTypeId
+
+**Signature**
+
+```ts
+export declare const ULIDTypeId: '@effect/schema/ULIDTypeId'
 ```
 
 Added in v1.0.0

--- a/package.json
+++ b/package.json
@@ -107,6 +107,6 @@
   "dependencies": {
     "@effect/data": "^0.12.10",
     "@effect/io": "^0.29.0",
-    "fast-check": "^3.10.0"
+    "fast-check": "^3.11.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: ^0.29.0
     version: 0.29.0
   fast-check:
-    specifier: ^3.10.0
-    version: 3.10.0
+    specifier: ^3.11.0
+    version: 3.11.0
 
 devDependencies:
   '@babel/cli':
@@ -3569,8 +3569,8 @@ packages:
     engines: {'0': node >=0.6.0}
     dev: true
 
-  /fast-check@3.10.0:
-    resolution: {integrity: sha512-I2FldZwnCbcY6iL+H0rp9m4D+O3PotuFu9FasWjMCzUedYHMP89/37JbSt6/n7Yq/IZmJDW0B2h30sPYdzrfzw==}
+  /fast-check@3.11.0:
+    resolution: {integrity: sha512-H2tctb7AGfFQfz+DEr3UWhJ3s47LXsGp5g3jeJr5tHjnf4xUvpArIqiwcDmL2EXiv+auLHIpF5MqaIpIKvpxiA==}
     engines: {node: '>=8.0.0'}
     dependencies:
       pure-rand: 6.0.1

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -2752,6 +2752,27 @@ export const UUID: Schema<string> = pipe(
 )
 
 /**
+ * @category type id
+ * @since 1.0.0
+ */
+export const ULIDTypeId = "@effect/schema/ULIDTypeId"
+
+const ulidRegex = /^[0-7][0-9A-HJKMNP-TV-Z]{25}$/i
+
+/**
+ * @category constructors
+ * @since 1.0.0
+ */
+export const ULID: Schema<string> = pipe(
+  string,
+  pattern(ulidRegex, {
+    typeId: ULIDTypeId,
+    title: "ULID",
+    arbitrary: (): Arbitrary<string> => (fc) => fc.ulid()
+  })
+)
+
+/**
  * @category string
  * @since 1.0.0
  */

--- a/test/Schema.ts
+++ b/test/Schema.ts
@@ -44,6 +44,7 @@ describe.concurrent("Schema", () => {
     expect(S.EndsWithTypeId).exist
     expect(S.IncludesTypeId).exist
     expect(S.UUIDTypeId).exist
+    expect(S.ULIDTypeId).exist
 
     expect(S.nullable).exist
 

--- a/test/data/filter/ULID.ts
+++ b/test/data/filter/ULID.ts
@@ -1,0 +1,18 @@
+import * as S from "@effect/schema/Schema"
+import * as Util from "@effect/schema/test/util"
+
+describe.concurrent("ULID", () => {
+  it("property tests", () => {
+    Util.roundtrip(S.ULID)
+  })
+
+  it("Decoder", async () => {
+    const schema = S.ULID
+    await Util.expectParseSuccess(schema, "01H4PGGGJVN2DKP2K1H7EH996V")
+    await Util.expectParseFailure(
+      schema,
+      "",
+      `Expected ULID, actual ""`
+    )
+  })
+})


### PR DESCRIPTION
The PR implements a schema for [ULID](https://github.com/ulid/spec)s, similarly to UUID. This requires an upgrade of `fast-check` where I introduced the ULID arbitrary in https://github.com/dubzzz/fast-check/pull/4020.