### PR TITLE
Fix instanceOf annotations

### DIFF
--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -2164,6 +2164,7 @@ export const instanceOf = <A extends abstract new(...args: any) => any>(
   constructor: A,
   options?: AnnotationOptions<object>
 ): Schema<InstanceType<A>, InstanceType<A>> => {
+  const annotations = toAnnotations(options)
   const schema = declare(
     [],
     struct({}),
@@ -2174,7 +2175,7 @@ export const instanceOf = <A extends abstract new(...args: any) => any>(
       [AST.TypeAnnotationId]: InstanceOfTypeId,
       [InstanceOfTypeId]: { constructor },
       [AST.DescriptionAnnotationId]: `an instance of ${constructor.name}`,
-      ...options
+      ...annotations
     }
   )
   return schema

--- a/test/data/Object.ts
+++ b/test/data/Object.ts
@@ -25,5 +25,12 @@ describe.concurrent("Object", () => {
       const pretty = Pretty.to(schema)
       expect(pretty(new Set())).toEqual("{}")
     })
+
+    it("Custom message", async () => {
+      const schema = S.instanceOf(Set, {
+        message: () => "This is a custom message"
+      })
+      await Util.expectParseFailure(schema, 1, `This is a custom message`)
+    })
   })
 })


### PR DESCRIPTION
Fixed: Annotations such as `message` are ignored when using `S.instanceOf`.