### PR TITLE
Add schema for BigintFromString

### DIFF
--- a/.changeset/beige-stingrays-move.md
+++ b/.changeset/beige-stingrays-move.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Add schema for BigintFromString

--- a/README.md
+++ b/README.md
@@ -1222,6 +1222,29 @@ parse(3); // 1
 
 ### Bigint transformations
 
+#### BigintFromString
+
+Transforms a `string` into a `bigint` by parsing the string using `BigInt`.
+
+```ts
+import * as S from "@effect/schema/Schema";
+
+// const schema: S.Schema<string, bigint>
+const schema = S.BigintFromString;
+const parse = S.parseSync(schema);
+
+// success cases
+parse("1"); // 1n
+parse("-1"); // -1n
+
+// failure cases
+parse("a"); // throws
+parse("1.5"); // throws
+parse("NaN"); // throws
+parse("Infinity"); // throws
+parse("-Infinity"); // throws
+```
+
 #### clamp
 
 Clamps a `bigint` between a minimum and a maximum value.

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -1442,6 +1442,46 @@ export const clampBigint = (min: bigint, max: bigint) =>
       identity
     )
 
+/**
+ * This combinator transforms a `string` into a `bigint` by parsing the string using the `BigInt` function.
+ *
+ * It returns an error if the value can't be converted (for example when non-numeric characters are provided).
+ *
+ * @param self - The schema representing the input string
+ *
+ * @category bigint
+ * @since 1.0.0
+ */
+export const bigintFromString = <I, A extends string>(self: Schema<I, A>): Schema<I, bigint> => {
+  const schema: Schema<I, bigint> = transformResult(
+    self,
+    bigint,
+    (s) => {
+      if (s.trim() === "") {
+        return PR.failure(PR.type(schema.ast, s))
+      }
+
+      try {
+        return PR.success(BigInt(s))
+      } catch (_) {
+        return PR.failure(PR.type(schema.ast, s))
+      }
+    },
+    (n) => PR.success(String(n) as A) // this is safe because `self` will check its input anyway
+  )
+  return schema
+}
+
+/**
+ * This schema transforms a `string` into a `bigint` by parsing the string using the `BigInt` function.
+ *
+ * It returns an error if the value can't be converted (for example when non-numeric characters are provided).
+ *
+ * @category bigint
+ * @since 1.0.0
+ */
+export const BigintFromString: Schema<string, bigint> = bigintFromString(string)
+
 // ---------------------------------------------
 // data/Boolean
 // ---------------------------------------------

--- a/test/data/Bigint.ts
+++ b/test/data/Bigint.ts
@@ -94,4 +94,53 @@ describe.concurrent("Bigint", () => {
     await Util.expectParseSuccess(schema, 0n, 0n)
     await Util.expectParseFailure(schema, 1n, "Expected a non-positive bigint, actual 1n")
   })
+
+  describe.concurrent("bigintFromString", () => {
+    const schema = S.BigintFromString
+
+    it("property tests", () => {
+      Util.roundtrip(schema)
+    })
+
+    it("Decoder", async () => {
+      await Util.expectParseSuccess(schema, "0", 0n)
+      await Util.expectParseSuccess(schema, "-0", -0n)
+      await Util.expectParseSuccess(schema, "1", 1n)
+
+      await Util.expectParseFailure(schema, "", `Expected string -> bigint, actual ""`)
+      await Util.expectParseFailure(schema, " ", `Expected string -> bigint, actual " "`)
+      await Util.expectParseFailure(schema, "1.2", `Expected string -> bigint, actual "1.2"`)
+      await Util.expectParseFailure(schema, "1AB", `Expected string -> bigint, actual "1AB"`)
+      await Util.expectParseFailure(schema, "AB1", `Expected string -> bigint, actual "AB1"`)
+      await Util.expectParseFailure(
+        schema,
+        "a",
+        `Expected string -> bigint, actual "a"`
+      )
+      await Util.expectParseFailure(
+        schema,
+        "a1",
+        `Expected string -> bigint, actual "a1"`
+      )
+    })
+
+    it("Encoder", async () => {
+      await Util.expectEncodeSuccess(schema, 1n, "1")
+    })
+
+    it("example", async () => {
+      const schema = S.BigintFromString // converts string schema to number schema
+
+      // success cases
+      await Util.expectParseSuccess(schema, "1", 1n)
+      await Util.expectParseSuccess(schema, "-1", -1n)
+
+      // failure cases
+      await Util.expectParseFailure(
+        schema,
+        "a",
+        `Expected string -> bigint, actual "a"`
+      )
+    })
+  })
 })


### PR DESCRIPTION
Implements #351.

Sometimes resource identifiers are very large integers represented as strings, e.g. through query params, and sometimes also via the response body, but stored as integers in the database. This schema will help parse such inputs.