### PR TITLE
feat: add `isSchema` guard

### DIFF
--- a/.changeset/shiny-bags-float.md
+++ b/.changeset/shiny-bags-float.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Update /data.

--- a/.changeset/slimy-walls-obey.md
+++ b/.changeset/slimy-walls-obey.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Add `_id` to `Schema`. Add `isSchema` guard.

--- a/docs/modules/Schema.ts.md
+++ b/docs/modules/Schema.ts.md
@@ -105,6 +105,8 @@ Added in v1.0.0
   - [encodePromise](#encodepromise)
   - [encodeResult](#encoderesult)
   - [encodeSync](#encodesync)
+- [guards](#guards)
+  - [isSchema](#isschema)
 - [model](#model)
   - [AnnotationOptions (type alias)](#annotationoptions-type-alias)
   - [BrandSchema (interface)](#brandschema-interface)
@@ -162,6 +164,8 @@ Added in v1.0.0
   - [startsWith](#startswith)
   - [trim](#trim)
   - [trimmed](#trimmed)
+- [symbol](#symbol-1)
+  - [TypeId (type alias)](#typeid-type-alias)
 - [type id](#type-id)
   - [BetweenBigintTypeId](#betweenbiginttypeid)
   - [BetweenTypeId](#betweentypeid)
@@ -1345,6 +1349,20 @@ export declare const encodeSync: <I, A>(schema: Schema<I, A>) => (a: A, options?
 
 Added in v1.0.0
 
+# guards
+
+## isSchema
+
+Tests if a value is a `Schema`.
+
+**Signature**
+
+```ts
+export declare const isSchema: (input: unknown) => input is Schema<unknown, unknown>
+```
+
+Added in v1.0.0
+
 # model
 
 ## AnnotationOptions (type alias)
@@ -1393,6 +1411,7 @@ Added in v1.0.0
 
 ```ts
 export interface Schema<From, To = From> extends Pipeable {
+  readonly _id: TypeId
   readonly From: (_: From) => From
   readonly To: (_: To) => To
   readonly ast: AST.AST
@@ -1968,6 +1987,18 @@ If what you were looking for was a combinator to trim strings, then check out th
 export declare const trimmed: <A extends string>(
   options?: AnnotationOptions<A> | undefined
 ) => <I>(self: Schema<I, A>) => Schema<I, A>
+```
+
+Added in v1.0.0
+
+# symbol
+
+## TypeId (type alias)
+
+**Signature**
+
+```ts
+export type TypeId = typeof TypeId
 ```
 
 Added in v1.0.0

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "global": []
   },
   "dependencies": {
-    "@effect/data": "^0.16.1",
+    "@effect/data": "^0.16.2",
     "@effect/io": "^0.35.2",
     "fast-check": "^3.11.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@effect/data':
-    specifier: ^0.16.1
-    version: 0.16.1
+    specifier: ^0.16.2
+    version: 0.16.2
   '@effect/io':
     specifier: ^0.35.2
     version: 0.35.2
@@ -782,8 +782,8 @@ packages:
     resolution: {integrity: sha512-/crHGujo0xnuHIYNc1VgP0HGJGFSoSqq88JFXe6FmFyXPpWt8Xu39LyLg7rchsxfXFeEdA9CrIZvLV5eswXV5g==}
     dev: true
 
-  /@effect/data@0.16.1:
-    resolution: {integrity: sha512-rIoLk+5xY1lakbzd7k5xbuPvfiR+BSQSrOyxX5Fo5oXWt1a29k31K/0Cq+9NtwqsAE7aNMlQtw6Z1d0Sxw1i9Q==}
+  /@effect/data@0.16.2:
+    resolution: {integrity: sha512-Q3ugteQz5gFGauskdZFdbCujA2op/sFu2PEArCjoJ8yHAQis/Fxq5Rc5dBdvqOlXCqmYHJBy57KGgudlT4+Ayw==}
     dev: false
 
   /@effect/docgen@0.1.2(@types/node@20.4.4)(typescript@5.1.6):
@@ -812,7 +812,7 @@ packages:
   /@effect/io@0.35.2:
     resolution: {integrity: sha512-+F9A5785QmjK8OOO5d5SDHcZjNwpp0D8nAf7PlGSXPBFxeex2S5qYhhlUbE1zBQeTZoDwp40UIIMtgTb8yFOTw==}
     dependencies:
-      '@effect/data': 0.16.1
+      '@effect/data': 0.16.2
     dev: false
 
   /@effect/language-service@0.0.19:

--- a/test/Schema.ts
+++ b/test/Schema.ts
@@ -360,4 +360,10 @@ describe.concurrent("Schema", () => {
       new Error("`optionalElement` is not supported on this schema")
     )
   })
+
+  it("isSchema", () => {
+    expect(S.isSchema(S.string)).toBe(true)
+    expect(S.isSchema(S.struct({ f: S.optional(S.string).toOption() }))).toBe(true)
+    expect(S.isSchema(S.string.pipe(S.brand("my-brand")))).toBe(true)
+  })
 })


### PR DESCRIPTION
In effect-http, I need a runtime check for whether an object is a `Schema`. I could do it in the lib structurally by checking the `ast` field but that is verbose and probably prone to errors when the AST changes.