### PR TITLE
Add combinator that splits a string into an array of strings

### DIFF
--- a/.changeset/gold-ladybugs-bow.md
+++ b/.changeset/gold-ladybugs-bow.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Adds combinator that splits a string into an array of strings

--- a/README.md
+++ b/README.md
@@ -1158,6 +1158,23 @@ Effect.runPromiseExit(parse("fail")).then(console.log);
 
 ### String transformations
 
+#### split
+
+The `split` combinator allows splitting a string into an array of strings.
+
+```ts
+import * as S from "@effect/schema/Schema";
+
+// const schema: S.Schema<string, string>
+const schema = S.string.pipe(S.split(","));
+const parse = S.parseSync(schema);
+
+parse(""); // [""]
+parse(","); // ["", ""]
+parse("a,"); // ["a", ""]
+parse("a,b"); // ["a", "b"]
+```
+
 #### Trim
 
 The `Trim` schema allows removing whitespaces from the beginning and end of a string.

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -21,6 +21,7 @@ import { pipeArguments } from "@effect/data/Pipeable"
 import type { Predicate, Refinement } from "@effect/data/Predicate"
 import { isDate, isObject } from "@effect/data/Predicate"
 import * as RA from "@effect/data/ReadonlyArray"
+import * as S from "@effect/data/String"
 import type { Arbitrary } from "@effect/schema/Arbitrary"
 import type { ParseOptions } from "@effect/schema/AST"
 import * as AST from "@effect/schema/AST"
@@ -2693,6 +2694,26 @@ export const trim = <I, A extends string>(self: Schema<I, A>): Schema<I, A> =>
  * @since 1.0.0
  */
 export const Trim: Schema<string, string> = trim(string)
+
+/**
+ * This combinator allows splitting a string into an array of strings.
+ *
+ * @category string
+ * @since 1.0.0
+ */
+export const split: {
+  (separator: string): <I>(self: Schema<I, string>) => Schema<I, ReadonlyArray<string>>
+  <I>(self: Schema<I, string>, separator: string): Schema<I, ReadonlyArray<string>>
+} = dual(
+  2,
+  <I>(self: Schema<I, string>, separator: string): Schema<I, ReadonlyArray<string>> =>
+    transform(
+      self,
+      array(string),
+      S.split(separator),
+      RA.join(separator)
+    )
+)
 
 /**
  * @category type id

--- a/test/data/String.ts
+++ b/test/data/String.ts
@@ -1,0 +1,33 @@
+import * as S from "@effect/schema/Schema"
+import * as Util from "@effect/schema/test/util"
+
+describe.concurrent("String", () => {
+  it("split (data-last)", async () => {
+    const schema = S.string.pipe(S.split(","))
+
+    Util.roundtrip(schema)
+
+    // Decoding
+    await Util.expectParseSuccess(schema, "", [""])
+    await Util.expectParseSuccess(schema, ",", ["", ""])
+    await Util.expectParseSuccess(schema, "a", ["a"])
+    await Util.expectParseSuccess(schema, ",a", ["", "a"])
+    await Util.expectParseSuccess(schema, "a,", ["a", ""])
+    await Util.expectParseSuccess(schema, "a,b", ["a", "b"])
+
+    // Encoding
+    await Util.expectEncodeSuccess(schema, [], "")
+    await Util.expectEncodeSuccess(schema, [""], "")
+    await Util.expectEncodeSuccess(schema, ["", ""], ",")
+    await Util.expectEncodeSuccess(schema, ["a"], "a")
+    await Util.expectEncodeSuccess(schema, ["", "a"], ",a")
+    await Util.expectEncodeSuccess(schema, ["a", ""], "a,")
+    await Util.expectEncodeSuccess(schema, ["a", "b"], "a,b")
+  })
+
+  it("split (data-first)", async () => {
+    const schema = S.split(S.string, ",")
+
+    await Util.expectParseSuccess(schema, "a,b", ["a", "b"])
+  })
+})


### PR DESCRIPTION
Partially addresses #352 as a response to the received feedback in #353.

The idea is that once we can split strings into arrays of strings, we could implement another combinator that allows transforming arrays of type I into arrays of type A. With those two combinators: `split`, and `arrayOf`, we could implement the same as the proposed `arrayFromDelimitedString` by chaining those combinators like so:

```ts
S.string.pipe(S.split(","), S.arrayOf(S.NumberFromString))
```