### PR TITLE
Add `compose`

### DIFF
--- a/.changeset/nice-ants-push.md
+++ b/.changeset/nice-ants-push.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Adds `compose`: a combinator that composes Schema<A, B> with Schema<B, C> into Schema<A, C>.

--- a/README.md
+++ b/README.md
@@ -983,6 +983,15 @@ S.struct({ a: S.string, b: S.string }).pipe(
 );
 ```
 
+## Compose
+
+The `compose` combinator allows you to combine two schemas.
+
+```ts
+// $ExpectType Schema<string, readonly number[]>
+S.compose(S.split(S.string, ","), S.array(S.NumberFromString));
+```
+
 ## InstanceOf
 
 In the following section, we demonstrate how to use the `instanceOf` combinator to create a `Schema` for a class instance.

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -917,6 +917,19 @@ export const extend: {
  * @category combinators
  * @since 1.0.0
  */
+export const compose: {
+  <B, C>(bc: Schema<B, C>): <A>(ab: Schema<A, B>) => Schema<A, C>
+  <A, B, C>(ab: Schema<A, B>, bc: Schema<B, C>): Schema<A, C>
+} = dual(
+  2,
+  <A, B, C>(ab: Schema<A, B>, bc: Schema<B, C>): Schema<A, C> =>
+    transform(ab, bc, identity, identity)
+)
+
+/**
+ * @category combinators
+ * @since 1.0.0
+ */
 export const lazy = <I, A = I>(
   f: () => Schema<I, A>,
   annotations?: AST.Annotated["annotations"]

--- a/test/compose.ts
+++ b/test/compose.ts
@@ -1,0 +1,16 @@
+import * as S from "@effect/schema/Schema"
+import * as Util from "@effect/schema/test/util"
+
+describe.concurrent("compose", async () => {
+  it("split string compose array of NumberFromString (dual)", async () => {
+    const schema = S.compose(S.split(S.string, ","), S.array(S.NumberFromString))
+    await Util.expectParseSuccess(schema, "1,2,3", [1, 2, 3])
+  })
+
+  it("struct compose struct", async () => {
+    const schema = S.struct({ a: S.split(S.string, ",") }).pipe(
+      S.compose(S.struct({ a: S.array(S.NumberFromString) }))
+    )
+    await Util.expectParseSuccess(schema, { a: "1,2,3" }, { a: [1, 2, 3] })
+  })
+})


### PR DESCRIPTION
Fully addresses https://github.com/Effect-TS/schema/issues/352 in combination with https://github.com/Effect-TS/schema/pull/359 as opposed to the approach outlined in https://github.com/Effect-TS/schema/pull/353.

Based on the suggestion from https://github.com/Effect-TS/schema/pull/359#issuecomment-1651019819.

The `compose` combinator allows one to directly transform `Schema<A, B>` to `Schema<B, C>` creating a `Schema<A, C>`.