### PR TITLE
Make `compose` more flexible to work with

### DIFF
--- a/.changeset/proud-candles-itch.md
+++ b/.changeset/proud-candles-itch.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Allow `compose` to work on schemas where the input type of one extends the output type of the other

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -918,8 +918,8 @@ export const extend: {
  * @since 1.0.0
  */
 export const compose: {
-  <B, C>(bc: Schema<B, C>): <A>(ab: Schema<A, B>) => Schema<A, C>
-  <A, B, C>(ab: Schema<A, B>, bc: Schema<B, C>): Schema<A, C>
+  <B1, B2 extends B1, C>(bc: Schema<B2, C>): <A>(ab: Schema<A, B1>) => Schema<A, C>
+  <A, B1, B2 extends B1, C>(ab: Schema<A, B1>, bc: Schema<B2, C>): Schema<A, C>
 } = dual(
   2,
   <A, B, C>(ab: Schema<A, B>, bc: Schema<B, C>): Schema<A, C> =>

--- a/test/compose.ts
+++ b/test/compose.ts
@@ -13,4 +13,10 @@ describe.concurrent("compose", async () => {
     )
     await Util.expectParseSuccess(schema, { a: "1,2,3" }, { a: [1, 2, 3] })
   })
+
+  it("unknown record compose struct", async () => {
+    const schema = S.record(S.string, S.unknown).pipe(S.compose(S.struct({ a: S.string })))
+    await Util.expectParseSuccess(schema, { a: "1" }, { a: "1" })
+    await Util.expectParseFailure(schema, { a: 1 }, "/a Expected string, actual 1")
+  })
 })


### PR DESCRIPTION
Implements #369.

Previously the following schema would not type check:

```ts
const schema = S.record(S.string, S.unknown).pipe(S.compose(S.struct({ a: S.string })))
```

With this change, `compose` becomes more flexible in a sense that it allows the composition of `Schema<A, B1>` and `Schema<B2, C>` into `Schema<A, C>` if and only if `B2 extends B1`.