### PR TITLE
WIP: added S.findAll, S.findFirst, S.findLast

### DIFF
--- a/.changeset/curvy-suns-brake.md
+++ b/.changeset/curvy-suns-brake.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+added S.findAll

--- a/dtslint/Schema.ts
+++ b/dtslint/Schema.ts
@@ -520,3 +520,6 @@ pipe(UnionFilter, S.filter(S.is(S.struct({ b: S.string }))))
 
 // $ExpectType Schema<number, number & Brand<"MyNumber">>
 pipe(S.number, S.filter((n): n is number & Brand<"MyNumber"> => n > 0))
+
+// $ExpectType Schema<readonly string[], readonly number[]>
+S.array(S.string).pipe(S.findAll(NumberFromString))

--- a/test/find.ts
+++ b/test/find.ts
@@ -1,0 +1,35 @@
+import * as S from "@effect/schema/Schema"
+import * as Util from "@effect/schema/test/util"
+
+const IntFromString = S.NumberFromString.pipe(S.int())
+
+describe("find", () => {
+  it("findAll", () => {
+    const schema = S.findAll(S.array(S.string), IntFromString) // Schema<string[], number[]>
+
+    Util.expectParseSuccess(schema, [], [])
+    Util.expectParseSuccess(schema, ["1"], [1])
+    Util.expectParseSuccess(schema, ["1", "a", "2", "1.5"], [1, 2])
+    Util.expectEncodeSuccess(schema, [], [])
+    Util.expectEncodeSuccess(schema, [1], ["1"])
+  })
+
+  it("findFirst", () => {
+    const schema = S.findFirst(S.array(S.string), IntFromString) // Schema<string[], number>
+
+    Util.expectParseSuccess(schema, ["1"], 1)
+    Util.expectParseSuccess(schema, ["1.5", "2"], 2)
+    Util.expectParseSuccess(schema, ["a", "1"], 1)
+    Util.expectEncodeSuccess(schema, 1, ["1"])
+  })
+
+  it("findLast", () => {
+    const schema = S.findLast(S.array(S.string), IntFromString) // Schema<string[], number>
+
+    Util.expectParseSuccess(schema, ["1"], 1)
+    Util.expectParseSuccess(schema, ["1", "2"], 2)
+    Util.expectParseSuccess(schema, ["a", "1"], 1)
+    Util.expectParseSuccess(schema, ["a", "1", "2"], 2)
+    Util.expectEncodeSuccess(schema, 1, ["1"])
+  })
+})


### PR DESCRIPTION
Adds S.findAll that finds all values matching a schema A in a schema I[] ignoring cases where the value doesn't match the inner schema. A WIP while awaiting feedback. I think findFirst and findLast fns would be useful as well. 

```ts
 import * as S from "@effect-ts/schema";

 const IntFromString = S.NumberFromString.pipe(S.int())
 const schema = S.findAll(S.array(S.string), IntFromString) // string[] -> int[]

 expect(S.parseSync(schema)(["1", "a", "2", "1.5"])).toEqual([1, 2])
 expect(S.encodeSync(schema)([1])).toEqual(["1"])
```

https://discord.com/channels/795981131316985866/1140667727791542395
https://github.com/Effect-TS/schema/issues/380
