### PR TITLE
Add support for Uint8Array

### DIFF
--- a/.changeset/olive-colts-thank.md
+++ b/.changeset/olive-colts-thank.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Add support for `Uint8Array`

--- a/docs/modules/Schema.ts.md
+++ b/docs/modules/Schema.ts.md
@@ -44,6 +44,11 @@ Added in v1.0.0
 - [ReadonlySet transformations](#readonlyset-transformations)
   - [readonlySet](#readonlyset)
   - [readonlySetFromSelf](#readonlysetfromself)
+- [Uint8Array constructors](#uint8array-constructors)
+  - [Uint8Array](#uint8array)
+  - [Uint8ArrayFromSelf](#uint8arrayfromself)
+- [Uint8Array transformations](#uint8array-transformations)
+  - [uint8ArrayFromNumbers](#uint8arrayfromnumbers)
 - [annotations](#annotations)
   - [annotations](#annotations-1)
   - [description](#description)
@@ -559,6 +564,46 @@ Added in v1.0.0
 
 ```ts
 export declare const readonlySetFromSelf: <I, A>(item: Schema<I, A>) => Schema<ReadonlySet<I>, ReadonlySet<A>>
+```
+
+Added in v1.0.0
+
+# Uint8Array constructors
+
+## Uint8Array
+
+A schema that transforms a `number` array into a `Uint8Array`.
+
+**Signature**
+
+```ts
+export declare const Uint8Array: Schema<readonly number[], Uint8Array>
+```
+
+Added in v1.0.0
+
+## Uint8ArrayFromSelf
+
+**Signature**
+
+```ts
+export declare const Uint8ArrayFromSelf: Schema<Uint8Array, Uint8Array>
+```
+
+Added in v1.0.0
+
+# Uint8Array transformations
+
+## uint8ArrayFromNumbers
+
+A combinator that transforms a `number` array into a `Uint8Array`.
+
+**Signature**
+
+```ts
+export declare const uint8ArrayFromNumbers: <I, A extends readonly number[]>(
+  self: Schema<I, A>
+) => Schema<I, Uint8Array>
 ```
 
 Added in v1.0.0

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -2597,7 +2597,6 @@ export const NonNegativeBigint: Schema<string, bigint> = bigint.pipe(
  */
 export const BigintFromNumber: Schema<number, bigint> = bigintFromNumber(number)
 
-
 // ---------------------------------------------
 // Uint8Array constructors
 // ---------------------------------------------
@@ -2611,10 +2610,13 @@ export const Uint8ArrayFromSelf: Schema<Uint8Array> = declare(
   struct({}),
   () => (u, _, ast) =>
     // TODO: Use `Predicate.isUint8Array` when it's available
-    !(u instanceof Uint8Array) ? ParseResult.failure(ParseResult.type(ast, u)) : ParseResult.success(u),
+    !(u instanceof Uint8Array)
+      ? ParseResult.failure(ParseResult.type(ast, u))
+      : ParseResult.success(u),
   {
     [AST.IdentifierAnnotationId]: "Uint8Array",
-    [Internal.PrettyHookId]: (): Pretty<Uint8Array> => (u8arr) => `new Uint8Array(${JSON.stringify(Array.from(u8arr))})`,
+    [Internal.PrettyHookId]: (): Pretty<Uint8Array> => (u8arr) =>
+      `new Uint8Array(${JSON.stringify(Array.from(u8arr))})`,
     [Internal.ArbitraryHookId]: (): Arbitrary<Uint8Array> => (fc) => fc.uint8Array()
   }
 )
@@ -2629,7 +2631,9 @@ export const Uint8ArrayFromSelf: Schema<Uint8Array> = declare(
  * @category Uint8Array transformations
  * @since 1.0.0
  */
-export const uint8ArrayFromNumbers = <I, A extends ReadonlyArray<number>>(self: Schema<I, A>): Schema<I, Uint8Array> =>
+export const uint8ArrayFromNumbers = <I, A extends ReadonlyArray<number>>(
+  self: Schema<I, A>
+): Schema<I, Uint8Array> =>
   transform(
     self,
     Uint8ArrayFromSelf,
@@ -2637,10 +2641,15 @@ export const uint8ArrayFromNumbers = <I, A extends ReadonlyArray<number>>(self: 
     (n) => Array.from(n) as unknown as A
   )
 
-const _Uint8Array: Schema<ReadonlyArray<number>, Uint8Array> = uint8ArrayFromNumbers(array(number.pipe(between(0, 255), annotations({
-  [AST.TitleAnnotationId]: "8-bit unsigned integer",
-  [AST.DescriptionAnnotationId]: "a 8-bit unsigned integer"
-}))))
+const _Uint8Array: Schema<ReadonlyArray<number>, Uint8Array> = uint8ArrayFromNumbers(
+  array(number.pipe(
+    between(0, 255),
+    annotations({
+      [AST.TitleAnnotationId]: "8-bit unsigned integer",
+      [AST.DescriptionAnnotationId]: "a 8-bit unsigned integer"
+    })
+  ))
+)
 
 export {
   /**

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -2597,6 +2597,61 @@ export const NonNegativeBigint: Schema<string, bigint> = bigint.pipe(
  */
 export const BigintFromNumber: Schema<number, bigint> = bigintFromNumber(number)
 
+
+// ---------------------------------------------
+// Uint8Array constructors
+// ---------------------------------------------
+
+/**
+ * @category Uint8Array constructors
+ * @since 1.0.0
+ */
+export const Uint8ArrayFromSelf: Schema<Uint8Array> = declare(
+  [],
+  struct({}),
+  () => (u, _, ast) =>
+    // TODO: Use `Predicate.isUint8Array` when it's available
+    !(u instanceof Uint8Array) ? ParseResult.failure(ParseResult.type(ast, u)) : ParseResult.success(u),
+  {
+    [AST.IdentifierAnnotationId]: "Uint8Array",
+    [Internal.PrettyHookId]: (): Pretty<Uint8Array> => (u8arr) => `new Uint8Array(${JSON.stringify(Array.from(u8arr))})`,
+    [Internal.ArbitraryHookId]: (): Arbitrary<Uint8Array> => (fc) => fc.uint8Array()
+  }
+)
+
+// ---------------------------------------------
+// Uint8Array transformations
+// ---------------------------------------------
+
+/**
+ * A combinator that transforms a `number` array into a `Uint8Array`.
+ *
+ * @category Uint8Array transformations
+ * @since 1.0.0
+ */
+export const uint8ArrayFromNumbers = <I, A extends ReadonlyArray<number>>(self: Schema<I, A>): Schema<I, Uint8Array> =>
+  transform(
+    self,
+    Uint8ArrayFromSelf,
+    (a) => Uint8Array.from(a),
+    (n) => Array.from(n) as unknown as A
+  )
+
+const _Uint8Array: Schema<ReadonlyArray<number>, Uint8Array> = uint8ArrayFromNumbers(array(number.pipe(between(0, 255), annotations({
+  [AST.TitleAnnotationId]: "8-bit unsigned integer",
+  [AST.DescriptionAnnotationId]: "a 8-bit unsigned integer"
+}))))
+
+export {
+  /**
+   * A schema that transforms a `number` array into a `Uint8Array`.
+   *
+   * @category Uint8Array constructors
+   * @since 1.0.0
+   */
+  _Uint8Array as Uint8Array
+}
+
 // ---------------------------------------------
 // ReadonlyArray filters
 // ---------------------------------------------

--- a/test/Uint8Array/Uint8Array.ts
+++ b/test/Uint8Array/Uint8Array.ts
@@ -10,7 +10,11 @@ describe.concurrent("Uint8Array/Uint8Array", () => {
 
   it("decoding", async () => {
     await Util.expectParseSuccess(schema, [0, 1, 2, 3], Uint8Array.from([0, 1, 2, 3]))
-    await Util.expectParseFailure(schema, [12354], "/0 Expected 8-bit unsigned integer, actual 12354")
+    await Util.expectParseFailure(
+      schema,
+      [12354],
+      "/0 Expected 8-bit unsigned integer, actual 12354"
+    )
   })
 
   it("encoding", async () => {

--- a/test/Uint8Array/Uint8Array.ts
+++ b/test/Uint8Array/Uint8Array.ts
@@ -1,0 +1,19 @@
+import * as S from "@effect/schema/Schema"
+import * as Util from "@effect/schema/test/util"
+
+describe.concurrent("Uint8Array/Uint8Array", () => {
+  const schema = S.Uint8Array
+
+  it("property tests", () => {
+    Util.roundtrip(schema)
+  })
+
+  it("decoding", async () => {
+    await Util.expectParseSuccess(schema, [0, 1, 2, 3], Uint8Array.from([0, 1, 2, 3]))
+    await Util.expectParseFailure(schema, [12354], "/0 Expected 8-bit unsigned integer, actual 12354")
+  })
+
+  it("encoding", async () => {
+    await Util.expectEncodeSuccess(schema, Uint8Array.from([0, 1, 2, 3]), [0, 1, 2, 3])
+  })
+})

--- a/test/Uint8Array/Uint8ArrayFromSelf.ts
+++ b/test/Uint8Array/Uint8ArrayFromSelf.ts
@@ -1,0 +1,28 @@
+import * as Pretty from "@effect/schema/Pretty"
+import * as S from "@effect/schema/Schema"
+import * as Util from "@effect/schema/test/util"
+
+describe.concurrent("Uint8Array/Uint8ArrayFromSelf", () => {
+  it("keyof", () => {
+    expect(S.keyof(S.Uint8ArrayFromSelf)).toEqual(S.never)
+  })
+
+  it("property tests", () => {
+    Util.roundtrip(S.Uint8ArrayFromSelf)
+  })
+
+  it("decoding", async () => {
+    await Util.expectParseSuccess(S.Uint8ArrayFromSelf, new Uint8Array(), new Uint8Array())
+    await Util.expectParseFailure(S.Uint8ArrayFromSelf, null, `Expected Uint8Array, actual null`)
+  })
+
+  it("encoding", async () => {
+    const u8arr = Uint8Array.from([0, 1, 2, 3])
+    await Util.expectEncodeSuccess(S.Uint8ArrayFromSelf, u8arr, u8arr)
+  })
+
+  it("pretty", () => {
+    const pretty = Pretty.to(S.Uint8ArrayFromSelf)
+    expect(pretty(Uint8Array.from([0, 1, 2, 3]))).toEqual("new Uint8Array([0,1,2,3])")
+  })
+})


### PR DESCRIPTION
Normally Uint8Array is serialized as an obect. I chose to serialize it as an array here which is a bit more compact and had some other benefits.

I'd like to add `hex` and `base64` schema support on top.