### PR TITLE
require explicit type parameter for dx

### DIFF
--- a/.changeset/lazy-pigs-cross.md
+++ b/.changeset/lazy-pigs-cross.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": minor
+---
+
+Enforce explicit `Schema.Class` type parameters for better developer experience

--- a/.changeset/lazy-pigs-cross.md
+++ b/.changeset/lazy-pigs-cross.md
@@ -1,5 +1,5 @@
 ---
-"@effect/schema": minor
+"@effect/schema": patch
 ---
 
-Enforce explicit `Schema.Class` type parameters for better developer experience
+Enforce explicit `Schema.Class` type parameters

--- a/docs/modules/Schema.ts.md
+++ b/docs/modules/Schema.ts.md
@@ -999,7 +999,9 @@ Added in v1.0.0
 ```ts
 export declare const Class: <Self = never>() => <Fields extends StructFields>(
   fields: Fields
-) => Self extends never ? never : Class<Simplify<FromStruct<Fields>>, Simplify<ToStruct<Fields>>, Self, Data.Case>
+) => [Self] extends [never]
+  ? 'missing Self generic - use `class Self extends Class<Self>()({ ... })`'
+  : Class<Simplify<FromStruct<Fields>>, Simplify<ToStruct<Fields>>, Self, Data.Case>
 ```
 
 Added in v1.0.0
@@ -1016,8 +1018,8 @@ export interface Class<I, A, Self, Inherited = Data.Case> extends Schema<I, Self
 
   readonly extend: <Extended = never>() => <FieldsB extends StructFields>(
     fields: FieldsB
-  ) => Extended extends never
-    ? never
+  ) => [Extended] extends [never]
+    ? 'missing Self generic - use `class Self extends Base.extend<Self>()({ ... })`'
     : Class<
         Simplify<Omit<I, keyof FieldsB> & FromStruct<FieldsB>>,
         Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>,
@@ -1029,16 +1031,16 @@ export interface Class<I, A, Self, Inherited = Data.Case> extends Schema<I, Self
     fields: FieldsB,
     decode: (input: A) => ParseResult.ParseResult<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>,
     encode: (input: Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>) => ParseResult.ParseResult<A>
-  ) => Transformed extends never
-    ? never
+  ) => [Transformed] extends [never]
+    ? 'missing Self generic - use `class Self extends Base.transform<Self>()({ ... })`'
     : Class<I, Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>, Transformed, Self>
 
   readonly transformFrom: <Transformed = never>() => <FieldsB extends StructFields>(
     fields: FieldsB,
     decode: (input: I) => ParseResult.ParseResult<Omit<I, keyof FieldsB> & FromStruct<FieldsB>>,
     encode: (input: Simplify<Omit<I, keyof FieldsB> & FromStruct<FieldsB>>) => ParseResult.ParseResult<I>
-  ) => Transformed extends never
-    ? never
+  ) => [Transformed] extends [never]
+    ? 'missing Self generic - use `class Self extends Base.transformFrom<Self>()({ ... })`'
     : Class<I, Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>, Transformed, Self>
 }
 ```

--- a/docs/modules/Schema.ts.md
+++ b/docs/modules/Schema.ts.md
@@ -997,9 +997,9 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const Class: <T>() => <Fields extends StructFields>(
+export declare const Class: <Self = never>() => <Fields extends StructFields>(
   fields: Fields
-) => Class<Simplify<FromStruct<Fields>>, Simplify<ToStruct<Fields>>, T, Data.Case>
+) => Self extends never ? never : Class<Simplify<FromStruct<Fields>>, Simplify<ToStruct<Fields>>, Self, Data.Case>
 ```
 
 Added in v1.0.0
@@ -1014,26 +1014,32 @@ export interface Class<I, A, Self, Inherited = Data.Case> extends Schema<I, Self
 
   readonly struct: Schema<I, A>
 
-  readonly extend: <Extended>() => <FieldsB extends StructFields>(
+  readonly extend: <Extended = never>() => <FieldsB extends StructFields>(
     fields: FieldsB
-  ) => Class<
-    Simplify<Omit<I, keyof FieldsB> & FromStruct<FieldsB>>,
-    Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>,
-    Extended,
-    Self
-  >
+  ) => Extended extends never
+    ? never
+    : Class<
+        Simplify<Omit<I, keyof FieldsB> & FromStruct<FieldsB>>,
+        Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>,
+        Extended,
+        Self
+      >
 
-  readonly transform: <Transformed>() => <FieldsB extends StructFields>(
+  readonly transform: <Transformed = never>() => <FieldsB extends StructFields>(
     fields: FieldsB,
     decode: (input: A) => ParseResult.ParseResult<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>,
     encode: (input: Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>) => ParseResult.ParseResult<A>
-  ) => Class<I, Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>, Transformed, Self>
+  ) => Transformed extends never
+    ? never
+    : Class<I, Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>, Transformed, Self>
 
-  readonly transformFrom: <Transformed>() => <FieldsB extends StructFields>(
+  readonly transformFrom: <Transformed = never>() => <FieldsB extends StructFields>(
     fields: FieldsB,
     decode: (input: I) => ParseResult.ParseResult<Omit<I, keyof FieldsB> & FromStruct<FieldsB>>,
     encode: (input: Simplify<Omit<I, keyof FieldsB> & FromStruct<FieldsB>>) => ParseResult.ParseResult<I>
-  ) => Class<I, Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>, Transformed, Self>
+  ) => Transformed extends never
+    ? never
+    : Class<I, Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>, Transformed, Self>
 }
 ```
 

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -3353,14 +3353,16 @@ export interface Class<I, A, Self, Inherited = Data.Case> extends Schema<I, Self
 
   readonly struct: Schema<I, A>
 
-  readonly extend: <Extended>() => <FieldsB extends StructFields>(fields: FieldsB) => Class<
+  readonly extend: <Extended = never>() => <FieldsB extends StructFields>(
+    fields: FieldsB
+  ) => Extended extends never ? never : Class<
     Simplify<Omit<I, keyof FieldsB> & FromStruct<FieldsB>>,
     Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>,
     Extended,
     Self
   >
 
-  readonly transform: <Transformed>() => <
+  readonly transform: <Transformed = never>() => <
     FieldsB extends StructFields
   >(
     fields: FieldsB,
@@ -3370,14 +3372,14 @@ export interface Class<I, A, Self, Inherited = Data.Case> extends Schema<I, Self
     encode: (
       input: Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>
     ) => ParseResult.ParseResult<A>
-  ) => Class<
+  ) => Transformed extends never ? never : Class<
     I,
     Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>,
     Transformed,
     Self
   >
 
-  readonly transformFrom: <Transformed>() => <
+  readonly transformFrom: <Transformed = never>() => <
     FieldsB extends StructFields
   >(
     fields: FieldsB,
@@ -3387,7 +3389,7 @@ export interface Class<I, A, Self, Inherited = Data.Case> extends Schema<I, Self
     encode: (
       input: Simplify<Omit<I, keyof FieldsB> & FromStruct<FieldsB>>
     ) => ParseResult.ParseResult<I>
-  ) => Class<
+  ) => Transformed extends never ? never : Class<
     I,
     Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>,
     Transformed,

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -3399,10 +3399,11 @@ export interface Class<I, A, Self, Inherited = Data.Case> extends Schema<I, Self
  * @category classes
  * @since 1.0.0
  */
-export const Class = <Self>() =>
+export const Class = <Self = never>() =>
 <Fields extends StructFields>(
   fields: Fields
-): Class<Simplify<FromStruct<Fields>>, Simplify<ToStruct<Fields>>, Self> =>
+): Self extends never ? never
+  : Class<Simplify<FromStruct<Fields>>, Simplify<ToStruct<Fields>>, Self> =>
   makeClass(struct(fields), fields, Data.Class.prototype)
 
 const makeClass = <I, A>(selfSchema: Schema<I, A>, selfFields: StructFields, base: any) => {

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -3355,12 +3355,14 @@ export interface Class<I, A, Self, Inherited = Data.Case> extends Schema<I, Self
 
   readonly extend: <Extended = never>() => <FieldsB extends StructFields>(
     fields: FieldsB
-  ) => Extended extends never ? never : Class<
-    Simplify<Omit<I, keyof FieldsB> & FromStruct<FieldsB>>,
-    Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>,
-    Extended,
-    Self
-  >
+  ) => [Extended] extends [never]
+    ? "missing Self generic - use `class Self extends Base.extend<Self>()({ ... })`"
+    : Class<
+      Simplify<Omit<I, keyof FieldsB> & FromStruct<FieldsB>>,
+      Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>,
+      Extended,
+      Self
+    >
 
   readonly transform: <Transformed = never>() => <
     FieldsB extends StructFields
@@ -3372,12 +3374,14 @@ export interface Class<I, A, Self, Inherited = Data.Case> extends Schema<I, Self
     encode: (
       input: Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>
     ) => ParseResult.ParseResult<A>
-  ) => Transformed extends never ? never : Class<
-    I,
-    Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>,
-    Transformed,
-    Self
-  >
+  ) => [Transformed] extends [never]
+    ? "missing Self generic - use `class Self extends Base.transform<Self>()({ ... })`"
+    : Class<
+      I,
+      Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>,
+      Transformed,
+      Self
+    >
 
   readonly transformFrom: <Transformed = never>() => <
     FieldsB extends StructFields
@@ -3389,12 +3393,14 @@ export interface Class<I, A, Self, Inherited = Data.Case> extends Schema<I, Self
     encode: (
       input: Simplify<Omit<I, keyof FieldsB> & FromStruct<FieldsB>>
     ) => ParseResult.ParseResult<I>
-  ) => Transformed extends never ? never : Class<
-    I,
-    Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>,
-    Transformed,
-    Self
-  >
+  ) => [Transformed] extends [never]
+    ? "missing Self generic - use `class Self extends Base.transformFrom<Self>()({ ... })`"
+    : Class<
+      I,
+      Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>,
+      Transformed,
+      Self
+    >
 }
 
 /**
@@ -3404,7 +3410,7 @@ export interface Class<I, A, Self, Inherited = Data.Case> extends Schema<I, Self
 export const Class = <Self = never>() =>
 <Fields extends StructFields>(
   fields: Fields
-): Self extends never ? never
+): [Self] extends [never] ? "missing Self generic - use `class Self extends Class<Self>()({ ... })`"
   : Class<Simplify<FromStruct<Fields>>, Simplify<ToStruct<Fields>>, Self> =>
   makeClass(struct(fields), fields, Data.Class.prototype)
 

--- a/test/Arbitrary/Class.ts
+++ b/test/Arbitrary/Class.ts
@@ -3,35 +3,35 @@ import { propertyTo } from "@effect/schema/test/Arbitrary/Arbitrary"
 
 describe.concurrent("class", () => {
   it("required property signature", () => {
-    class Class extends S.Class()({
+    class Class extends S.Class<Class>()({
       a: S.number
     }) {}
     propertyTo(Class)
   })
 
   it("required property signature with undefined", () => {
-    class Class extends S.Class()({
+    class Class extends S.Class<Class>()({
       a: S.union(S.number, S.undefined)
     }) {}
     propertyTo(Class)
   })
 
   it("optional property signature", () => {
-    class Class extends S.Class()({
+    class Class extends S.Class<Class>()({
       a: S.optional(S.number)
     }) {}
     propertyTo(Class)
   })
 
   it("optional property signature with undefined", () => {
-    class Class extends S.Class()({
+    class Class extends S.Class<Class>()({
       a: S.optional(S.union(S.number, S.undefined))
     }) {}
     propertyTo(Class)
   })
 
   it("baseline", () => {
-    class Class extends S.Class()({
+    class Class extends S.Class<Class>()({
       a: S.string,
       b: S.NumberFromString
     }) {}


### PR DESCRIPTION
@tim-smart It's super easy to forget passing in the self-referencing `S.Class<>` type parameter (./cc @datner)

I'm not sure if there's a better way to solve this dx issue but this at least blows up if you forget to pass it ;-)