### PR TITLE
don't default to `never`

### DIFF
--- a/docs/modules/Schema.ts.md
+++ b/docs/modules/Schema.ts.md
@@ -997,10 +997,10 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const Class: <Self = never>() => <Fields extends StructFields>(
+export declare const Class: <Self>() => <Fields extends StructFields>(
   fields: Fields
-) => [Self] extends [never]
-  ? 'missing Self generic - use `class Self extends Class<Self>()({ ... })`'
+) => [unknown] extends [Self]
+  ? 'Missing `Self` generic - use `class Self extends Class<Self>()({ ... })`'
   : Class<Simplify<FromStruct<Fields>>, Simplify<ToStruct<Fields>>, Self, Data.Case>
 ```
 
@@ -1016,10 +1016,10 @@ export interface Class<I, A, Self, Inherited = Data.Case> extends Schema<I, Self
 
   readonly struct: Schema<I, A>
 
-  readonly extend: <Extended = never>() => <FieldsB extends StructFields>(
+  readonly extend: <Extended>() => <FieldsB extends StructFields>(
     fields: FieldsB
-  ) => [Extended] extends [never]
-    ? 'missing Self generic - use `class Self extends Base.extend<Self>()({ ... })`'
+  ) => [unknown] extends [Extended]
+    ? MissingSelfGeneric<'Base.extend'>
     : Class<
         Simplify<Omit<I, keyof FieldsB> & FromStruct<FieldsB>>,
         Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>,
@@ -1027,20 +1027,20 @@ export interface Class<I, A, Self, Inherited = Data.Case> extends Schema<I, Self
         Self
       >
 
-  readonly transform: <Transformed = never>() => <FieldsB extends StructFields>(
+  readonly transform: <Transformed>() => <FieldsB extends StructFields>(
     fields: FieldsB,
     decode: (input: A) => ParseResult.ParseResult<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>,
     encode: (input: Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>) => ParseResult.ParseResult<A>
-  ) => [Transformed] extends [never]
-    ? 'missing Self generic - use `class Self extends Base.transform<Self>()({ ... })`'
+  ) => [unknown] extends [Transformed]
+    ? MissingSelfGeneric<'Base.transform'>
     : Class<I, Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>, Transformed, Self>
 
-  readonly transformFrom: <Transformed = never>() => <FieldsB extends StructFields>(
+  readonly transformFrom: <Transformed>() => <FieldsB extends StructFields>(
     fields: FieldsB,
     decode: (input: I) => ParseResult.ParseResult<Omit<I, keyof FieldsB> & FromStruct<FieldsB>>,
     encode: (input: Simplify<Omit<I, keyof FieldsB> & FromStruct<FieldsB>>) => ParseResult.ParseResult<I>
-  ) => [Transformed] extends [never]
-    ? 'missing Self generic - use `class Self extends Base.transformFrom<Self>()({ ... })`'
+  ) => [unknown] extends [Transformed]
+    ? MissingSelfGeneric<'Base.transformFrom'>
     : Class<I, Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>, Transformed, Self>
 }
 ```

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -3344,6 +3344,10 @@ export const data = <
 // classes
 // ---------------------------------------------
 
+/** @internal */
+type MissingSelfGeneric<Usage extends string> =
+  `Missing \`Self\` generic - use \`class Self extends ${Usage}<Self>()({ ... })\``
+
 /**
  * @category classes
  * @since 1.0.0
@@ -3353,10 +3357,9 @@ export interface Class<I, A, Self, Inherited = Data.Case> extends Schema<I, Self
 
   readonly struct: Schema<I, A>
 
-  readonly extend: <Extended = never>() => <FieldsB extends StructFields>(
+  readonly extend: <Extended>() => <FieldsB extends StructFields>(
     fields: FieldsB
-  ) => [Extended] extends [never]
-    ? "missing Self generic - use `class Self extends Base.extend<Self>()({ ... })`"
+  ) => [unknown] extends [Extended] ? MissingSelfGeneric<"Base.extend">
     : Class<
       Simplify<Omit<I, keyof FieldsB> & FromStruct<FieldsB>>,
       Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>,
@@ -3364,7 +3367,7 @@ export interface Class<I, A, Self, Inherited = Data.Case> extends Schema<I, Self
       Self
     >
 
-  readonly transform: <Transformed = never>() => <
+  readonly transform: <Transformed>() => <
     FieldsB extends StructFields
   >(
     fields: FieldsB,
@@ -3374,8 +3377,7 @@ export interface Class<I, A, Self, Inherited = Data.Case> extends Schema<I, Self
     encode: (
       input: Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>
     ) => ParseResult.ParseResult<A>
-  ) => [Transformed] extends [never]
-    ? "missing Self generic - use `class Self extends Base.transform<Self>()({ ... })`"
+  ) => [unknown] extends [Transformed] ? MissingSelfGeneric<"Base.transform">
     : Class<
       I,
       Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>,
@@ -3383,7 +3385,7 @@ export interface Class<I, A, Self, Inherited = Data.Case> extends Schema<I, Self
       Self
     >
 
-  readonly transformFrom: <Transformed = never>() => <
+  readonly transformFrom: <Transformed>() => <
     FieldsB extends StructFields
   >(
     fields: FieldsB,
@@ -3393,8 +3395,7 @@ export interface Class<I, A, Self, Inherited = Data.Case> extends Schema<I, Self
     encode: (
       input: Simplify<Omit<I, keyof FieldsB> & FromStruct<FieldsB>>
     ) => ParseResult.ParseResult<I>
-  ) => [Transformed] extends [never]
-    ? "missing Self generic - use `class Self extends Base.transformFrom<Self>()({ ... })`"
+  ) => [unknown] extends [Transformed] ? MissingSelfGeneric<"Base.transformFrom">
     : Class<
       I,
       Simplify<Omit<A, keyof FieldsB> & ToStruct<FieldsB>>,
@@ -3407,10 +3408,10 @@ export interface Class<I, A, Self, Inherited = Data.Case> extends Schema<I, Self
  * @category classes
  * @since 1.0.0
  */
-export const Class = <Self = never>() =>
+export const Class = <Self>() =>
 <Fields extends StructFields>(
   fields: Fields
-): [Self] extends [never] ? "missing Self generic - use `class Self extends Class<Self>()({ ... })`"
+): [unknown] extends [Self] ? MissingSelfGeneric<"Class">
   : Class<Simplify<FromStruct<Fields>>, Simplify<ToStruct<Fields>>, Self> =>
   makeClass(struct(fields), fields, Data.Class.prototype)
 


### PR DESCRIPTION
Sorry @tim-smart, I think this is nicer. Keep the `unknown` in place instead of defaulting to `never` in case of failed inferrence (so always unless passed explicitly).