### PR TITLE
Schema: remove *Result APIs

### DIFF
--- a/.changeset/light-taxis-impress.md
+++ b/.changeset/light-taxis-impress.md
@@ -1,0 +1,10 @@
+---
+"@effect/schema": minor
+---
+
+Schema: remove \*Result APIs
+
+- decodeResult (use decode instead)
+- encodeResult (use encode instead)
+- parseResult (use parse instead)
+- validateResult (use validate instead)

--- a/docs/modules/Parser.ts.md
+++ b/docs/modules/Parser.ts.md
@@ -17,21 +17,18 @@ Added in v1.0.0
   - [decodeEither](#decodeeither)
   - [decodeOption](#decodeoption)
   - [decodePromise](#decodepromise)
-  - [decodeResult](#decoderesult)
   - [decodeSync](#decodesync)
 - [encoding](#encoding)
   - [encode](#encode)
   - [encodeEither](#encodeeither)
   - [encodeOption](#encodeoption)
   - [encodePromise](#encodepromise)
-  - [encodeResult](#encoderesult)
   - [encodeSync](#encodesync)
 - [parsing](#parsing)
   - [parse](#parse)
   - [parseEither](#parseeither)
   - [parseOption](#parseoption)
   - [parsePromise](#parsepromise)
-  - [parseResult](#parseresult)
   - [parseSync](#parsesync)
 - [utils](#utils)
   - [defaultParseOption](#defaultparseoption)
@@ -42,7 +39,6 @@ Added in v1.0.0
   - [validateEither](#validateeither)
   - [validateOption](#validateoption)
   - [validatePromise](#validatepromise)
-  - [validateResult](#validateresult)
   - [validateSync](#validatesync)
 
 ---
@@ -93,18 +89,6 @@ Added in v1.0.0
 export declare const decodePromise: <I, A>(
   schema: Schema.Schema<I, A>
 ) => (i: I, options?: AST.ParseOptions) => Promise<A>
-```
-
-Added in v1.0.0
-
-## decodeResult
-
-**Signature**
-
-```ts
-export declare const decodeResult: <I, A>(
-  schema: Schema.Schema<I, A>
-) => (i: I, options?: AST.ParseOptions) => ParseResult.ParseResult<A>
 ```
 
 Added in v1.0.0
@@ -169,18 +153,6 @@ export declare const encodePromise: <I, A>(
 
 Added in v1.0.0
 
-## encodeResult
-
-**Signature**
-
-```ts
-export declare const encodeResult: <I, A>(
-  schema: Schema.Schema<I, A>
-) => (a: A, options?: AST.ParseOptions) => ParseResult.ParseResult<I>
-```
-
-Added in v1.0.0
-
 ## encodeSync
 
 **Signature**
@@ -237,18 +209,6 @@ Added in v1.0.0
 export declare const parsePromise: <_, A>(
   schema: Schema.Schema<_, A>
 ) => (i: unknown, options?: AST.ParseOptions) => Promise<A>
-```
-
-Added in v1.0.0
-
-## parseResult
-
-**Signature**
-
-```ts
-export declare const parseResult: <_, A>(
-  schema: Schema.Schema<_, A>
-) => (i: unknown, options?: AST.ParseOptions) => ParseResult.ParseResult<A>
 ```
 
 Added in v1.0.0
@@ -343,18 +303,6 @@ Added in v1.0.0
 export declare const validatePromise: <_, A>(
   schema: Schema.Schema<_, A>
 ) => (i: unknown, options?: AST.ParseOptions) => Promise<A>
-```
-
-Added in v1.0.0
-
-## validateResult
-
-**Signature**
-
-```ts
-export declare const validateResult: <_, A>(
-  schema: Schema.Schema<_, A>
-) => (a: unknown, options?: AST.ParseOptions) => ParseResult.ParseResult<A>
 ```
 
 Added in v1.0.0

--- a/docs/modules/Schema.ts.md
+++ b/docs/modules/Schema.ts.md
@@ -127,14 +127,12 @@ Added in v1.0.0
   - [decodeEither](#decodeeither)
   - [decodeOption](#decodeoption)
   - [decodePromise](#decodepromise)
-  - [decodeResult](#decoderesult)
   - [decodeSync](#decodesync)
 - [encoding](#encoding)
   - [encode](#encode)
   - [encodeEither](#encodeeither)
   - [encodeOption](#encodeoption)
   - [encodePromise](#encodepromise)
-  - [encodeResult](#encoderesult)
   - [encodeSync](#encodesync)
 - [encoding constructors](#encoding-constructors)
   - [Base64](#base64)
@@ -181,7 +179,6 @@ Added in v1.0.0
   - [parseEither](#parseeither)
   - [parseOption](#parseoption)
   - [parsePromise](#parsepromise)
-  - [parseResult](#parseresult)
   - [parseSync](#parsesync)
 - [primitives](#primitives)
   - [any](#any)
@@ -286,7 +283,6 @@ Added in v1.0.0
   - [validateEither](#validateeither)
   - [validateOption](#validateoption)
   - [validatePromise](#validatepromise)
-  - [validateResult](#validateresult)
   - [validateSync](#validatesync)
 
 ---
@@ -1551,18 +1547,6 @@ export declare const decodePromise: <I, A>(
 
 Added in v1.0.0
 
-## decodeResult
-
-**Signature**
-
-```ts
-export declare const decodeResult: <I, A>(
-  schema: Schema<I, A>
-) => (i: I, options?: ParseOptions | undefined) => ParseResult.ParseResult<A>
-```
-
-Added in v1.0.0
-
 ## decodeSync
 
 **Signature**
@@ -1619,18 +1603,6 @@ Added in v1.0.0
 export declare const encodePromise: <I, A>(
   schema: Schema<I, A>
 ) => (a: A, options?: ParseOptions | undefined) => Promise<I>
-```
-
-Added in v1.0.0
-
-## encodeResult
-
-**Signature**
-
-```ts
-export declare const encodeResult: <I, A>(
-  schema: Schema<I, A>
-) => (a: A, options?: ParseOptions | undefined) => ParseResult.ParseResult<I>
 ```
 
 Added in v1.0.0
@@ -2109,18 +2081,6 @@ Added in v1.0.0
 export declare const parsePromise: <_, A>(
   schema: Schema<_, A>
 ) => (i: unknown, options?: ParseOptions | undefined) => Promise<A>
-```
-
-Added in v1.0.0
-
-## parseResult
-
-**Signature**
-
-```ts
-export declare const parseResult: <_, A>(
-  schema: Schema<_, A>
-) => (i: unknown, options?: ParseOptions | undefined) => ParseResult.ParseResult<A>
 ```
 
 Added in v1.0.0
@@ -3211,18 +3171,6 @@ Added in v1.0.0
 export declare const validatePromise: <_, A>(
   schema: Schema<_, A>
 ) => (i: unknown, options?: ParseOptions | undefined) => Promise<A>
-```
-
-Added in v1.0.0
-
-## validateResult
-
-**Signature**
-
-```ts
-export declare const validateResult: <_, A>(
-  schema: Schema<_, A>
-) => (a: unknown, options?: ParseOptions | undefined) => ParseResult.ParseResult<A>
 ```
 
 Added in v1.0.0

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -129,11 +129,6 @@ export {
    * @category decoding
    * @since 1.0.0
    */
-  decodeResult,
-  /**
-   * @category decoding
-   * @since 1.0.0
-   */
   decodeSync,
   /**
    * @category encoding
@@ -155,11 +150,6 @@ export {
    * @since 1.0.0
    */
   encodePromise,
-  /**
-   * @category encoding
-   * @since 1.0.0
-   */
-  encodeResult,
   /**
    * @category encoding
    * @since 1.0.0
@@ -194,11 +184,6 @@ export {
    * @category parsing
    * @since 1.0.0
    */
-  parseResult,
-  /**
-   * @category parsing
-   * @since 1.0.0
-   */
   parseSync,
   /**
    * @category validation
@@ -220,11 +205,6 @@ export {
    * @since 1.0.0
    */
   validatePromise,
-  /**
-   * @category validation
-   * @since 1.0.0
-   */
-  validateResult,
   /**
    * @category validation
    * @since 1.0.0
@@ -2995,7 +2975,7 @@ export const optionFromSelf = <I, A>(
     [value],
     optionInline(value),
     (isDecoding, value) => {
-      const parse = isDecoding ? Parser.parseResult(value) : Parser.encodeResult(value)
+      const parse = isDecoding ? Parser.parse(value) : Parser.encode(value)
       return (u, options, ast) =>
         !Option.isOption(u) ?
           ParseResult.failure(ParseResult.type(ast, u)) :
@@ -3080,8 +3060,8 @@ export const eitherFromSelf = <IE, E, IA, A>(
     [left, right],
     eitherInline(left, right),
     (isDecoding, left, right) => {
-      const parseLeft = isDecoding ? Parser.parseResult(left) : Parser.encodeResult(left)
-      const parseRight = isDecoding ? Parser.parseResult(right) : Parser.encodeResult(right)
+      const parseLeft = isDecoding ? Parser.parse(left) : Parser.encode(left)
+      const parseRight = isDecoding ? Parser.parse(right) : Parser.encode(right)
       return (u, options, ast) =>
         !Either.isEither(u) ?
           ParseResult.failure(ParseResult.type(ast, u)) :
@@ -3156,8 +3136,8 @@ export const readonlyMapFromSelf = <IK, K, IV, V>(
     }),
     (isDecoding, key, value) => {
       const parse = isDecoding
-        ? Parser.parseResult(array(tuple(key, value)))
-        : Parser.encodeResult(array(tuple(key, value)))
+        ? Parser.parse(array(tuple(key, value)))
+        : Parser.encode(array(tuple(key, value)))
       return (u, options, ast) =>
         !isMap(u) ?
           ParseResult.failure(ParseResult.type(ast, u)) :
@@ -3211,7 +3191,7 @@ export const readonlySetFromSelf = <I, A>(
       size: number
     }),
     (isDecoding, item) => {
-      const parse = isDecoding ? Parser.parseResult(array(item)) : Parser.encodeResult(array(item))
+      const parse = isDecoding ? Parser.parse(array(item)) : Parser.encode(array(item))
       return (u, options, ast) =>
         !isSet(u) ?
           ParseResult.failure(ParseResult.type(ast, u)) :
@@ -3259,7 +3239,7 @@ export const chunkFromSelf = <I, A>(item: Schema<I, A>): Schema<Chunk.Chunk<I>, 
       length: number
     }),
     (isDecoding, item) => {
-      const parse = isDecoding ? Parser.parseResult(array(item)) : Parser.encodeResult(array(item))
+      const parse = isDecoding ? Parser.parse(array(item)) : Parser.encode(array(item))
       return (u, options, ast) => {
         if (Chunk.isChunk(u)) {
           return Chunk.isEmpty(u)
@@ -3320,7 +3300,7 @@ export const dataFromSelf = <
     [item],
     item,
     (isDecoding, item) => {
-      const parse = isDecoding ? Parser.parseResult(item) : Parser.encodeResult(item)
+      const parse = isDecoding ? Parser.parse(item) : Parser.encode(item)
       return (u, options, ast) =>
         !Equal.isEqual(u) ?
           ParseResult.failure(ParseResult.type(ast, u)) :

--- a/test/Parser.test.ts
+++ b/test/Parser.test.ts
@@ -8,13 +8,6 @@ import * as S from "@effect/schema/Schema"
 import * as Util from "@effect/schema/test/util"
 
 describe("Parser", () => {
-  it("exports", () => {
-    expect(S.parseResult).exist
-    expect(S.decodeResult).exist
-    expect(S.validateResult).exist
-    expect(S.encodeResult).exist
-  })
-
   it("asserts", () => {
     const schema = S.string
     expect(P.asserts(schema)("a")).toEqual(undefined)
@@ -119,14 +112,6 @@ describe("Parser", () => {
     )
   })
 
-  it("validateResult", () => {
-    const schema = S.NumberFromString
-    expect(P.validateResult(schema)(1)).toEqual(E.right(1))
-    expect(P.validateResult(schema)("1")).toEqual(
-      E.left(PR.parseError([PR.type(S.number.ast, "1")]))
-    )
-  })
-
   it("validatePromise", async () => {
     const schema = S.NumberFromString
     await Util.resolves(P.validatePromise(schema)(1), 1)
@@ -140,11 +125,6 @@ describe("Parser", () => {
     expect(await Effect.runPromise(Effect.either(P.validate(schema)("1")))).toEqual(
       E.left(PR.parseError([PR.type(S.number.ast, "1")]))
     )
-  })
-
-  it("encodeResult", () => {
-    const schema = S.NumberFromString
-    expect(P.encodeResult(schema)(1)).toEqual(E.right("1"))
   })
 
   it("encodeEither", () => {
@@ -176,7 +156,7 @@ describe("Parser", () => {
         S.declare(
           [],
           S.struct({ _tag: S.literal("a") }),
-          () => P.parseResult(S.struct({ _tag: S.literal("a") }))
+          () => P.parse(S.struct({ _tag: S.literal("a") }))
         ).ast
       )
     ).toEqual([["_tag", AST.createLiteral("a")]])

--- a/test/Schema/exports.test.ts
+++ b/test/Schema/exports.test.ts
@@ -6,25 +6,21 @@ describe("Schema/exports", () => {
     expect(S.parseSync).exist
     expect(S.parseOption).exist
     expect(S.parseEither).exist
-    expect(S.parseResult).exist
 
     expect(S.decode).exist
     expect(S.decodeSync).exist
     expect(S.decodeOption).exist
     expect(S.decodeEither).exist
-    expect(S.decodeResult).exist
 
     expect(S.encode).exist
     expect(S.encodeSync).exist
     expect(S.encodeOption).exist
     expect(S.encodeEither).exist
-    expect(S.encodeResult).exist
 
     expect(S.validate).exist
     expect(S.validateSync).exist
     expect(S.validateOption).exist
     expect(S.validateEither).exist
-    expect(S.validateResult).exist
 
     expect(S.GreaterThanBigintTypeId).exist
     expect(S.GreaterThanOrEqualToBigintTypeId).exist

--- a/test/Schema/parseJson.test.ts
+++ b/test/Schema/parseJson.test.ts
@@ -1,8 +1,6 @@
 import * as S from "@effect/schema/Schema"
 import * as Util from "@effect/schema/test/util"
 
-console.log("isBun", Util.isBun)
-
 describe("Schema/ParseJson", () => {
   it("decoding", async () => {
     const schema = S.ParseJson

--- a/test/dev.test.ts
+++ b/test/dev.test.ts
@@ -1,12 +1,49 @@
-import * as O from "@effect/data/Option"
+import * as Effect from "@effect/io/Effect"
+import * as PR from "@effect/schema/ParseResult"
 import * as S from "@effect/schema/Schema"
 import * as Util from "@effect/schema/test/util"
 
 describe("dev", () => {
-  it("tmp", async () => {
-    const schema = S.struct({
-      thing: S.optional(S.struct({ id: S.number })).toOption()
+  it.skip("tmp", async () => {
+    const User = S.struct({ name: S.string })
+
+    const UserFromString = S.transformOrFail(
+      S.string,
+      User,
+      (str) => {
+        return Effect.try({
+          try: () => JSON.parse(str) as unknown,
+          catch: () => PR.parseError([PR.missing])
+        }).pipe(Effect.flatMap(S.parse(User)))
+      },
+      (user) => {
+        return Effect.try({
+          try: () => JSON.stringify(user),
+          catch: () => PR.parseError([PR.missing])
+        })
+      }
+    )
+
+    // const UserFromString2 = S.transformOrFail(
+    //   S.string,
+    //   User,
+    //   (str) => {
+    //     try {
+    //       return S.parseResult(User)(JSON.parse(str))
+    //     } catch (e) {
+    //       return PR.fail(PR.parseError([PR.missing]))
+    //     }
+    //   },
+    //   (user) => {
+    //     try {
+    //       return PR.success(JSON.stringify(user))
+    //     } catch (e) {
+    //       return PR.fail(PR.parseError([PR.missing]))
+    //     }
+    //   }
+    // )
+    await Util.expectParseSuccess(UserFromString, JSON.stringify({ name: "steve" }), {
+      name: "steve"
     })
-    await Util.expectParseSuccess(schema, { thing: { id: 123 } }, { thing: O.some({ id: 123 }) })
   })
 })


### PR DESCRIPTION
- decodeResult (use decode instead)
- encodeResult (use encode instead)
- parseResult (use parse instead)
- validateResult (use validate instead)