### PR TITLE
fix encode discriminated union with transformation

### DIFF
--- a/.changeset/plenty-sheep-clean.md
+++ b/.changeset/plenty-sheep-clean.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+fix encode discriminated union with transformation


### PR DESCRIPTION
`_getLiterals` should consider the case it is an encoding operation.

```typescript
P.encodeSync(
  S.union(
    S.transform(
      S.struct({ _tag: S.literal("a") }),
      S.struct({ _tag: S.literal("b") }),
      () => ({ _tag: "b" as const }),
      () => ({ _tag: "a" as const })
    ),
    S.struct({ _tag: S.literal("c") })
  )
)({ _tag: "b" })
// BEFORE:
// Error: error(s) found
// └─ ["_tag"]
//    └─ Expected "a" or "c", actual "b"
// NOW:
// { _tag: "a" }

P.encodeSync(
  S.union(
    S.struct({
      _tag: S.transform(
        S.literal("a"),
        S.literal("b"),
        () => "b" as const,
        () => "a" as const
      )
    }),
    S.struct({ _tag: S.literal("c") })
  )
)({ _tag: "b" })
// BEFORE:
// Error: error(s) found
// └─ ["_tag"]
//    └─ Expected "a" or "c", actual "b"
// NOW:
// { _tag: "a" }

```