### PR TITLE
feat: updated Schema.brand BrandError

### DIFF
--- a/.changeset/tough-fireants-shop.md
+++ b/.changeset/tough-fireants-shop.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+updated Schema.brand BrandErrors

--- a/.changeset/tough-fireants-shop.md
+++ b/.changeset/tough-fireants-shop.md
@@ -2,4 +2,4 @@
 "@effect/schema": patch
 ---
 
-updated Schema.brand BrandErrors
+Replaced TreeFormatter with ArrayFormatter for BrandErrors when using Schema.brand

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -26,7 +26,7 @@ import * as Internal from "./internal/common"
 import * as Parser from "./Parser"
 import * as ParseResult from "./ParseResult"
 import type { Pretty } from "./Pretty"
-import * as TreeFormatter from "./TreeFormatter"
+import * as ArrayFormatter from "./ArrayFormatter"
 
 // ---------------------------------------------
 // model
@@ -976,7 +976,7 @@ export const brand = <B extends string | symbol, A>(
     either: (input: unknown) =>
       Either.mapLeft(
         validateEither(input),
-        (e) => [{ meta: input, message: TreeFormatter.formatErrors(e.errors) }]
+        (e) => ArrayFormatter.formatErrors(e.errors).map(err => ({ meta: err.path, message: err.message }))
       ),
     is: (input: unknown): input is A & Brand.Brand<B> => is(input),
     pipe() {

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -20,13 +20,13 @@ import * as ReadonlyArray from "effect/ReadonlyArray"
 import * as S from "effect/String"
 import type { Simplify } from "effect/Types"
 import type { Arbitrary } from "./Arbitrary"
+import * as ArrayFormatter from "./ArrayFormatter"
 import type { ParseOptions } from "./AST"
 import * as AST from "./AST"
 import * as Internal from "./internal/common"
 import * as Parser from "./Parser"
 import * as ParseResult from "./ParseResult"
 import type { Pretty } from "./Pretty"
-import * as ArrayFormatter from "./ArrayFormatter"
 
 // ---------------------------------------------
 // model
@@ -976,7 +976,11 @@ export const brand = <B extends string | symbol, A>(
     either: (input: unknown) =>
       Either.mapLeft(
         validateEither(input),
-        (e) => ArrayFormatter.formatErrors(e.errors).map(err => ({ meta: err.path, message: err.message }))
+        (e) =>
+          ArrayFormatter.formatErrors(e.errors).map((err) => ({
+            meta: err.path,
+            message: err.message
+          }))
       ),
     is: (input: unknown): input is A & Brand.Brand<B> => is(input),
     pipe() {

--- a/test/Schema/brand.test.ts
+++ b/test/Schema/brand.test.ts
@@ -72,9 +72,8 @@ describe("Schema/brand", () => {
     const Int = S.string.pipe(S.numberFromString, S.int(), S.brand("Int"))
     expect(Int.either(1)).toEqual(Either.right(1))
     expect(Int.either(1.2)).toEqual(Either.left([{
-      meta: 1.2,
-      message: `error(s) found
-└─ Expected integer, actual 1.2`
+      meta: [],
+      message: "Expected integer, actual 1.2"
     }]))
   })
 


### PR DESCRIPTION
Replaced TreeFormatter with ArrayFormatter for BrandErrors when using Schema.brand