### PR TITLE
fix changeset publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,8 @@ jobs:
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1
+        with:
+          publish: pnpm changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
I accidentally removed this.

The `version` script is optional (e.g. in case one wants to run custom scripts before or after versioning). But the `publish` script is required if one wants to publish. Since we don't run any custom logic there we can just do `pnpm changeset publish` directly.