### PR TITLE
add rename API, closes #549

### DIFF
--- a/.changeset/cyan-vans-brake.md
+++ b/.changeset/cyan-vans-brake.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Schema: add rename API

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Welcome to the documentation for `@effect/schema`, **a library for defining and 
 | Operation       | Description                                                                                                     |
 | --------------- | --------------------------------------------------------------------------------------------------------------- |
 | Parsing         | Convert from `unknown` value to output type `A`.                                                                |
-| Decoding        | Transforming data from an input type `I` to an output type `A`.                                                |
+| Decoding        | Transforming data from an input type `I` to an output type `A`.                                                 |
 | Encoding        | Converting data from an output type `A` back to an input type `I`.                                              |
 | Asserting       | Verifying that a value adheres to the schema's output type `A`.                                                 |
 | Arbitraries     | Generate arbitraries for [fast-check](https://github.com/dubzzz/fast-check) testing.                            |
@@ -108,7 +108,7 @@ const schema: Schema.Schema<{
 }>
 */
 const schema = Schema.struct({
-  myfield: Schema.optional(Schema.string.pipe(Schema.nonEmpty()))
+  myfield: Schema.optional(Schema.string.pipe(Schema.nonEmpty())),
 });
 
 Schema.decodeSync(schema)({ myfield: undefined }); // Error: Type 'undefined' is not assignable to type 'string'.ts(2379)
@@ -131,7 +131,7 @@ const schema: Schema.Schema<{
 }>
 */
 const schema = Schema.struct({
-  myfield: Schema.optional(Schema.string.pipe(Schema.nonEmpty()))
+  myfield: Schema.optional(Schema.string.pipe(Schema.nonEmpty())),
 });
 
 Schema.decodeSync(schema)({ myfield: undefined }); // No type error, but a decoding failure occurs
@@ -177,7 +177,7 @@ import * as S from "@effect/schema/Schema";
 
 const Person = S.struct({
   name: S.string,
-  age: S.number
+  age: S.number,
 });
 ```
 
@@ -220,7 +220,7 @@ import * as Either from "effect/Either";
 
 const Person = S.struct({
   name: S.string,
-  age: S.number
+  age: S.number,
 });
 
 const parsePerson = S.parseEither(Person);
@@ -298,7 +298,7 @@ const PersonId = S.number;
 const Person = S.struct({
   id: PersonId,
   name: S.string,
-  age: S.number
+  age: S.number,
 });
 
 const asyncSchema = S.transformOrFail(
@@ -355,14 +355,14 @@ import * as S from "@effect/schema/Schema";
 
 const Person = S.struct({
   name: S.string,
-  age: S.number
+  age: S.number,
 });
 
 console.log(
   S.parseSync(Person)({
     name: "Bob",
     age: 40,
-    email: "bob@example.com"
+    email: "bob@example.com",
   })
 );
 /*
@@ -373,7 +373,7 @@ S.parseSync(Person)(
   {
     name: "Bob",
     age: 40,
-    email: "bob@example.com"
+    email: "bob@example.com",
   },
   { onExcessProperty: "error" }
 );
@@ -396,14 +396,14 @@ import * as S from "@effect/schema/Schema";
 
 const Person = S.struct({
   name: S.string,
-  age: S.number
+  age: S.number,
 });
 
 S.parseSync(Person)(
   {
     name: "Bob",
     age: "abc",
-    email: "bob@example.com"
+    email: "bob@example.com",
   },
   { errors: "all", onExcessProperty: "error" }
 );
@@ -430,7 +430,7 @@ const Age = S.NumberFromString;
 
 const Person = S.struct({
   name: S.string,
-  age: Age
+  age: Age,
 });
 
 const encoded = S.encodeEither(Person)({ name: "Alice", age: 30 });
@@ -458,7 +458,7 @@ import * as E from "effect/Either";
 
 const Person = S.struct({
   name: S.string,
-  age: S.number
+  age: S.number,
 });
 
 const result = S.parseEither(Person)({});
@@ -495,7 +495,7 @@ import * as E from "effect/Either";
 
 const Person = S.struct({
   name: S.string,
-  age: S.number
+  age: S.number,
 });
 
 const result = S.parseEither(Person)(
@@ -533,7 +533,7 @@ import * as S from "@effect/schema/Schema";
 
 const Person = S.struct({
   name: S.string,
-  age: S.number
+  age: S.number,
 });
 
 // const isPerson: (u: unknown) => u is Person
@@ -551,7 +551,7 @@ import * as S from "@effect/schema/Schema";
 
 const Person = S.struct({
   name: S.string,
-  age: S.number
+  age: S.number,
 });
 
 // const assertsPerson: (input: unknown, options?: ParseOptions) => asserts input is { readonly name: string; readonly age: number; }
@@ -586,7 +586,7 @@ import * as fc from "fast-check";
 
 const Person = S.struct({
   name: S.string,
-  age: S.string.pipe(S.numberFromString, S.int())
+  age: S.string.pipe(S.numberFromString, S.int()),
 });
 
 // Arbitrary for the To type
@@ -621,7 +621,7 @@ import * as P from "@effect/schema/Pretty";
 
 const Person = S.struct({
   name: S.string,
-  age: S.number
+  age: S.number,
 });
 
 const PersonPretty = P.to(Person);
@@ -640,7 +640,7 @@ import * as JSONSchema from "@effect/schema/JSONSchema";
 
 const Person = S.struct({
   name: S.string,
-  age: S.number
+  age: S.number,
 });
 
 const jsonSchema = JSONSchema.to(Person);
@@ -685,7 +685,7 @@ const Name = S.string.pipe(S.identifier("Name"));
 const Age = S.number.pipe(S.identifier("Age"));
 const Person = S.struct({
   name: Name,
-  age: Age
+  age: Age,
 });
 
 const jsonSchema = JSONSchema.to(Person);
@@ -742,7 +742,7 @@ interface Category {
 const schema: S.Schema<Category> = S.lazy<Category>(() =>
   S.struct({
     name: S.string,
-    categories: S.array(schema)
+    categories: S.array(schema),
   })
 ).pipe(S.identifier("Category"));
 
@@ -795,7 +795,7 @@ import * as Equivalence from "@effect/schema/Equivalence";
 
 const Person = S.struct({
   name: S.string,
-  age: S.number
+  age: S.number,
 });
 
 // $ExpectType Equivalence<{ readonly name: string; readonly age: number; }>
@@ -1023,7 +1023,7 @@ const UserIdSchema = S.string.pipe(S.fromBrand(UserId));
 ```ts
 enum Fruits {
   Apple,
-  Banana
+  Banana,
 }
 
 // $ExpectType Schema<Fruits>
@@ -1095,12 +1095,12 @@ import * as S from "@effect/schema/Schema";
 
 const Circle = S.struct({
   kind: S.literal("circle"),
-  radius: S.number
+  radius: S.number,
 });
 
 const Square = S.struct({
   kind: S.literal("square"),
-  sideLength: S.number
+  sideLength: S.number,
 });
 
 const Shape = S.union(Circle, Square);
@@ -1120,11 +1120,11 @@ If you're working on a TypeScript project and you've defined a simple union to r
 import * as S from "@effect/schema/Schema";
 
 const Circle = S.struct({
-  radius: S.number
+  radius: S.number,
 });
 
 const Square = S.struct({
-  sideLength: S.number
+  sideLength: S.number,
 });
 
 const Shape = S.union(Circle, Square);
@@ -1139,11 +1139,11 @@ import * as S from "@effect/schema/Schema";
 import { pipe } from "effect/Function";
 
 const Circle = S.struct({
-  radius: S.number
+  radius: S.number,
 });
 
 const Square = S.struct({
-  sideLength: S.number
+  sideLength: S.number,
 });
 
 const DiscriminatedShape = S.union(
@@ -1165,12 +1165,12 @@ const DiscriminatedShape = S.union(
 
 expect(S.parseSync(DiscriminatedShape)({ radius: 10 })).toEqual({
   kind: "circle",
-  radius: 10
+  radius: 10,
 });
 
 expect(S.parseSync(DiscriminatedShape)({ sideLength: 10 })).toEqual({
   kind: "square",
-  sideLength: 10
+  sideLength: 10,
 });
 ```
 
@@ -1191,14 +1191,14 @@ const DiscriminatedShape = S.union(
 // parsing
 expect(S.parseSync(DiscriminatedShape)({ radius: 10 })).toEqual({
   kind: "circle",
-  radius: 10
+  radius: 10,
 });
 
 // encoding
 expect(
   S.encodeSync(DiscriminatedShape)({
     kind: "circle",
-    radius: 10
+    radius: 10,
   })
 ).toEqual({ radius: 10 });
 ```
@@ -1282,7 +1282,7 @@ S.struct({ a: S.string, b: S.number, c: S.optional(S.boolean) });
 ```ts
 S.struct({
   // the use of S.optional should be the last step in the pipeline and not preceeded by other combinators like S.nullable
-  c: S.boolean.pipe(S.optional, S.nullable) // type checker error
+  c: S.boolean.pipe(S.optional, S.nullable), // type checker error
 });
 ```
 
@@ -1290,7 +1290,7 @@ and it must be rewritten like this:
 
 ```ts
 S.struct({
-  c: S.boolean.pipe(S.nullable, S.optional) // ok
+  c: S.boolean.pipe(S.nullable, S.optional), // ok
 });
 ```
 
@@ -1334,6 +1334,24 @@ encode({ a: O.none() }) // {}
 encode({ a: O.some(1) }) // { a: 1 }
 ```
 
+### Renaming Properties
+
+To rename one or more properties, you can utilize the `rename` API:
+
+```ts
+import * as Schema from "@effect/schema/Schema";
+
+// Original Schema
+const originalSchema = Schema.struct({ a: Schema.string, b: Schema.number });
+
+// Renaming the "a" property to "c"
+const renamedSchema = Schema.rename(originalSchema, { a: "c" });
+
+Schema.parseSync(renamedSchema)({ a: "a", b: 1 }); // Output: { c: "a", b: 1 }
+```
+
+In the example above, we have an original schema with properties "a" and "b." Using the `rename` API, we create a new schema where we rename the "a" property to "c." The resulting schema, when used with `Schema.parseSync`, transforms the input object by renaming the specified property.
+
 ## Classes
 
 When working with schemas, you have a choice beyond the `S.struct` constructor. You can leverage the power of classes through the `Class` utility, which comes with its own set of advantages tailored to common use cases.
@@ -1354,7 +1372,7 @@ import * as S from "@effect/schema/Schema";
 // Define your schema by providing the type to `Class` and the desired fields
 class Person extends S.Class<Person>()({
   id: S.number,
-  name: S.string.pipe(S.nonEmpty())
+  name: S.string.pipe(S.nonEmpty()),
 }) {}
 ```
 
@@ -1386,7 +1404,7 @@ import * as S from "@effect/schema/Schema";
 
 class Person extends S.Class<Person>()({
   id: S.number,
-  name: S.string.pipe(S.nonEmpty())
+  name: S.string.pipe(S.nonEmpty()),
 }) {
   get upperName() {
     return this.name.toUpperCase();
@@ -1417,7 +1435,7 @@ In situations where you need to augment your existing class with more fields, th
 ```ts
 // Extend an existing schema `Class` using the `extend` utility
 class PersonWithAge extends Person.extend<PersonWithAge>()({
-  age: S.number
+  age: S.number,
 }) {
   get isAdult() {
     return this.age >= 18;
@@ -1594,7 +1612,7 @@ interface Category {
 const Category: S.Schema<Category> = S.lazy(() =>
   S.struct({
     name: S.string,
-    subcategories: S.array(Category)
+    subcategories: S.array(Category),
   })
 );
 ```
@@ -1617,7 +1635,7 @@ interface Operation {
 const Expression: S.Schema<Expression> = S.lazy(() =>
   S.struct({
     type: S.literal("expression"),
-    value: S.union(S.number, Operation)
+    value: S.union(S.number, Operation),
   })
 );
 
@@ -1626,7 +1644,7 @@ const Operation: S.Schema<Operation> = S.lazy(() =>
     type: S.literal("operation"),
     operator: S.union(S.literal("+"), S.literal("-")),
     left: Expression,
-    right: Expression
+    right: Expression,
   })
 );
 ```
@@ -1733,7 +1751,7 @@ const api = (url: string) =>
         }
         throw new Error(String(res.status));
       }),
-    catch: (e) => new Error(String(e))
+    catch: (e) => new Error(String(e)),
   });
 
 const PeopleId = S.string.pipe(S.brand("PeopleId"));
@@ -1745,7 +1763,7 @@ const PeopleIdFromString = S.transformOrFail(
     Effect.mapBoth(api(`https://swapi.dev/api/people/${s}`), {
       onFailure: (e) =>
         ParseResult.parseError([ParseResult.type(PeopleId.ast, s, e.message)]),
-      onSuccess: () => s
+      onSuccess: () => s,
     }),
   ParseResult.success
 );
@@ -2042,7 +2060,7 @@ S.Schema<{
 const schema = S.data(
   S.struct({
     name: S.string,
-    age: S.number
+    age: S.number,
   })
 );
 
@@ -2082,7 +2100,7 @@ const schema: Schema<{
 */
 const schema = Schema.struct({
   a: Schema.string,
-  b: Schema.optionFromNullable(Schema.number)
+  b: Schema.optionFromNullable(Schema.number),
 });
 
 // parsing
@@ -2182,7 +2200,7 @@ const parse = S.parseSync(schema);
 parse([
   [1, "a"],
   [2, "b"],
-  [3, "c"]
+  [3, "c"],
 ]); // new Map([[1, "a"], [2, "b"], [3, "c"]])
 ```
 
@@ -2195,7 +2213,7 @@ import * as S from "@effect/schema/Schema";
 
 const LongString = S.string.pipe(
   S.filter((s) => s.length >= 10, {
-    message: () => "a string at least 10 characters long"
+    message: () => "a string at least 10 characters long",
   })
 );
 
@@ -2215,7 +2233,7 @@ const LongString = S.string.pipe(
     identifier: "LongString",
     jsonSchema: { minLength: 10 },
     description:
-      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
   })
 );
 ```

--- a/docs/modules/Schema.ts.md
+++ b/docs/modules/Schema.ts.md
@@ -197,6 +197,8 @@ Added in v1.0.0
   - [undefined](#undefined)
   - [unknown](#unknown)
   - [void](#void)
+- [renaming](#renaming)
+  - [rename](#rename)
 - [string constructors](#string-constructors)
   - [NonEmpty](#nonempty)
   - [ParseJson](#parsejson)
@@ -2299,6 +2301,21 @@ Added in v1.0.0
 
 ```ts
 export declare const void: Schema<void, void>
+```
+
+Added in v1.0.0
+
+# renaming
+
+## rename
+
+**Signature**
+
+```ts
+export declare const rename: <I, A, const M extends { readonly [K in keyof A]?: PropertyKey | undefined }>(
+  schema: Schema<I, A>,
+  mapping: M
+) => Schema<I, Simplify<Rename<A, M>>>
 ```
 
 Added in v1.0.0

--- a/dtslint/Schema.ts
+++ b/dtslint/Schema.ts
@@ -452,6 +452,27 @@ const lazy2: S.Schema<LazyFrom2, LazyTo2> = S.lazy(() =>
 )
 
 // ---------------------------------------------
+// rename
+// ---------------------------------------------
+
+// $ExpectType Schema<{ readonly a: string; readonly b: number; }, { readonly a: string; readonly b: number; }>
+S.rename(S.struct({ a: S.string, b: S.number }), {})
+
+// $ExpectType Schema<{ readonly a: string; readonly b: number; }, { readonly c: string; readonly b: number; }>
+S.rename(S.struct({ a: S.string, b: S.number }), { a: 'c' })
+
+// $ExpectType Schema<{ readonly a: string; readonly b: number; }, { readonly c: string; readonly d: number; }>
+S.rename(S.struct({ a: S.string, b: S.number }), { a: 'c', b: 'd' })
+
+const a = Symbol.for('@effect/schema/dtslint/a')
+
+// $ExpectType Schema<{ readonly a: string; readonly b: number; }, { readonly [a]: string; readonly b: number; }>
+S.rename(S.struct({ a: S.string, b: S.number }), { a: a })
+
+// @ts-expect-error
+S.rename(S.struct({ a: S.string, b: S.number }), { 'c': 'd' })
+
+// ---------------------------------------------
 // optionFromSelf
 // ---------------------------------------------
 

--- a/src/AST.ts
+++ b/src/AST.ts
@@ -2,7 +2,7 @@
  * @since 1.0.0
  */
 
-import { pipe } from "effect/Function"
+import { identity, pipe } from "effect/Function"
 import * as Number from "effect/Number"
 import * as Option from "effect/Option"
 import * as Order from "effect/Order"
@@ -1705,4 +1705,51 @@ const _keyof = (ast: AST): ReadonlyArray<AST> => {
     default:
       throw new Error(`keyof: unsupported schema (${ast._tag})`)
   }
+}
+
+/** @internal */
+export const compose = (ab: AST, cd: AST): AST => createTransform(ab, cd, composeTransformation)
+
+/** @internal */
+export const rename = (ast: AST, mapping: { readonly [K in PropertyKey]?: PropertyKey }): AST => {
+  switch (ast._tag) {
+    case "TypeLiteral": {
+      const propertySignatureTransforms: Array<PropertySignatureTransform> = []
+      for (const key in mapping) {
+        const name = mapping[key]
+        if (name !== undefined) {
+          propertySignatureTransforms.push(createPropertySignatureTransform(
+            key,
+            name,
+            createFinalPropertySignatureTransformation(
+              identity,
+              identity
+            )
+          ))
+        }
+      }
+      return createTransform(
+        ast,
+        createTypeLiteral(
+          ast.propertySignatures.map((ps) => {
+            const name = mapping[ps.name]
+            return name === undefined ? ps : createPropertySignature(
+              name,
+              to(ps.type),
+              ps.isOptional,
+              ps.isReadonly,
+              ps.annotations
+            )
+          }),
+          ast.indexSignatures
+        ),
+        createTypeLiteralTransformation(propertySignatureTransforms)
+      )
+    }
+    case "Lazy":
+      return createLazy(() => rename(ast.f(), mapping))
+    case "Transform":
+      return compose(ast, rename(to(ast), mapping))
+  }
+  throw new Error(`cannot rename ${ast._tag}`)
 }

--- a/src/AST.ts
+++ b/src/AST.ts
@@ -1715,7 +1715,7 @@ export const rename = (ast: AST, mapping: { readonly [K in PropertyKey]?: Proper
   switch (ast._tag) {
     case "TypeLiteral": {
       const propertySignatureTransforms: Array<PropertySignatureTransform> = []
-      for (const key in mapping) {
+      for (const key of Internal.ownKeys(mapping)) {
         const name = mapping[key]
         if (name !== undefined) {
           propertySignatureTransforms.push(createPropertySignatureTransform(

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -1161,7 +1161,7 @@ export const compose: {
 } = dual(
   2,
   <A, B, C, D>(ab: Schema<A, B>, cd: Schema<C, D>): Schema<A, D> =>
-    make(AST.createTransform(ab.ast, cd.ast, AST.composeTransformation))
+    make(AST.compose(ab.ast, cd.ast))
 )
 
 /**
@@ -1512,6 +1512,29 @@ export const jsonSchema =
 export const equivalence =
   <A>(equivalence: Equivalence.Equivalence<A>) => <I>(self: Schema<I, A>): Schema<I, A> =>
     make(AST.setAnnotation(self.ast, Internal.EquivalenceHookId, () => equivalence))
+
+// ---------------------------------------------
+// property signature renaming
+// ---------------------------------------------
+
+type Rename<A, M> = {
+  [
+    K in keyof A as K extends keyof M ? M[K] extends PropertyKey ? M[K]
+      : never
+      : K
+  ]: A[K]
+}
+
+/**
+ * @category renaming
+ * @since 1.0.0
+ */
+export const rename = <I, A, const M extends { readonly [K in keyof A]?: PropertyKey }>(
+  schema: Schema<I, A>,
+  mapping: M
+): Schema<I, Simplify<Rename<A, M>>> => {
+  return make(AST.rename(schema.ast, mapping))
+}
 
 // ---------------------------------------------
 // string filters

--- a/src/internal/common.ts
+++ b/src/internal/common.ts
@@ -48,8 +48,8 @@ export const maxSafeInteger = BigInt(Number.MAX_SAFE_INTEGER)
 export const minSafeInteger = BigInt(Number.MIN_SAFE_INTEGER)
 
 /** @internal */
-export const ownKeys = (o: object): ReadonlyArray<PropertyKey> =>
-  (Object.keys(o) as ReadonlyArray<PropertyKey>).concat(Object.getOwnPropertySymbols(o))
+export const ownKeys = (o: object): Array<PropertyKey> =>
+  (Object.keys(o) as Array<PropertyKey>).concat(Object.getOwnPropertySymbols(o))
 
 /** @internal */
 export const memoizeThunk = <A>(f: () => A): () => A => {

--- a/test/Schema/rename.test.ts
+++ b/test/Schema/rename.test.ts
@@ -2,25 +2,46 @@ import * as S from "@effect/schema/Schema"
 import * as Util from "@effect/schema/test/util"
 import { describe, it } from "vitest"
 
-describe("Schema/rename", () => {
-  it("string key", async () => {
-    const schema = S.struct({ a: S.string, b: S.number })
-    const renamed = S.rename(schema, { a: "c" })
+describe("Schema > rename", () => {
+  describe("Struct", () => {
+    it("from string key to string key", async () => {
+      const schema = S.struct({ a: S.string, b: S.number })
+      const renamed = S.rename(schema, { a: "c" })
 
-    await Util.expectParseSuccess(renamed, { a: "a", b: 1 }, { c: "a", b: 1 })
-    await Util.expectEncodeSuccess(renamed, { c: "a", b: 1 }, { a: "a", b: 1 })
+      await Util.expectParseSuccess(renamed, { a: "a", b: 1 }, { c: "a", b: 1 })
+      await Util.expectEncodeSuccess(renamed, { c: "a", b: 1 }, { a: "a", b: 1 })
+    })
+
+    it("from string key to symbol key", async () => {
+      const c = Symbol.for("@effect/schema/test/c")
+      const schema = S.struct({ a: S.string, b: S.number })
+      const renamed = S.rename(schema, { a: c })
+
+      await Util.expectParseSuccess(renamed, { a: "a", b: 1 }, { [c]: "a", b: 1 })
+      await Util.expectEncodeSuccess(renamed, { [c]: "a", b: 1 }, { a: "a", b: 1 })
+    })
+
+    it("from symbol key to string key", async () => {
+      const a = Symbol.for("@effect/schema/test/a")
+      const schema = S.struct({ [a]: S.string, b: S.number })
+      const renamed = S.rename(schema, { [a]: "c" })
+
+      await Util.expectParseSuccess(renamed, { [a]: "a", b: 1 }, { c: "a", b: 1 })
+      await Util.expectEncodeSuccess(renamed, { c: "a", b: 1 }, { [a]: "a", b: 1 })
+    })
+
+    it("from symbol key to symbol key", async () => {
+      const a = Symbol.for("@effect/schema/test/a")
+      const c = Symbol.for("@effect/schema/test/c")
+      const schema = S.struct({ [a]: S.string, b: S.number })
+      const renamed = S.rename(schema, { [a]: c })
+
+      await Util.expectParseSuccess(renamed, { [a]: "a", b: 1 }, { [c]: "a", b: 1 })
+      await Util.expectEncodeSuccess(renamed, { [c]: "a", b: 1 }, { [a]: "a", b: 1 })
+    })
   })
 
-  it("symbol key", async () => {
-    const c = Symbol.for("@effect/schema/test/c")
-    const schema = S.struct({ a: S.string, b: S.number })
-    const renamed = S.rename(schema, { a: c })
-
-    await Util.expectParseSuccess(renamed, { a: "a", b: 1 }, { [c]: "a", b: 1 })
-    await Util.expectEncodeSuccess(renamed, { [c]: "a", b: 1 }, { a: "a", b: 1 })
-  })
-
-  it("double renaming", async () => {
+  it("Transform (renaming twice)", async () => {
     const schema = S.struct({ a: S.string, b: S.number })
     const renamed = S.rename(schema, { a: "c" })
     const renamed2 = S.rename(renamed, { c: "d" })
@@ -29,7 +50,7 @@ describe("Schema/rename", () => {
     await Util.expectEncodeSuccess(renamed2, { d: "a", b: 1 }, { a: "a", b: 1 })
   })
 
-  it("lazy", async () => {
+  it("Lazy", async () => {
     interface A {
       readonly a: string
       readonly as: ReadonlyArray<A>

--- a/test/Schema/rename.test.ts
+++ b/test/Schema/rename.test.ts
@@ -1,0 +1,54 @@
+import * as S from "@effect/schema/Schema"
+import * as Util from "@effect/schema/test/util"
+import { describe, it } from "vitest"
+
+describe("Schema/rename", () => {
+  it("string key", async () => {
+    const schema = S.struct({ a: S.string, b: S.number })
+    const renamed = S.rename(schema, { a: "c" })
+
+    await Util.expectParseSuccess(renamed, { a: "a", b: 1 }, { c: "a", b: 1 })
+    await Util.expectEncodeSuccess(renamed, { c: "a", b: 1 }, { a: "a", b: 1 })
+  })
+
+  it("symbol key", async () => {
+    const c = Symbol.for("@effect/schema/test/c")
+    const schema = S.struct({ a: S.string, b: S.number })
+    const renamed = S.rename(schema, { a: c })
+
+    await Util.expectParseSuccess(renamed, { a: "a", b: 1 }, { [c]: "a", b: 1 })
+    await Util.expectEncodeSuccess(renamed, { [c]: "a", b: 1 }, { a: "a", b: 1 })
+  })
+
+  it("double renaming", async () => {
+    const schema = S.struct({ a: S.string, b: S.number })
+    const renamed = S.rename(schema, { a: "c" })
+    const renamed2 = S.rename(renamed, { c: "d" })
+
+    await Util.expectParseSuccess(renamed2, { a: "a", b: 1 }, { d: "a", b: 1 })
+    await Util.expectEncodeSuccess(renamed2, { d: "a", b: 1 }, { a: "a", b: 1 })
+  })
+
+  it("lazy", async () => {
+    interface A {
+      readonly a: string
+      readonly as: ReadonlyArray<A>
+    }
+    const schema: S.Schema<A> = S.lazy<A>(() =>
+      S.struct({
+        a: S.string,
+        as: S.array(schema)
+      })
+    )
+    const renamed = S.rename(schema, { a: "c" })
+
+    await Util.expectParseSuccess(renamed, { a: "a1", as: [{ a: "a2", as: [] }] }, {
+      c: "a1",
+      as: [{ a: "a2", as: [] }]
+    })
+    await Util.expectEncodeSuccess(renamed, {
+      c: "a1",
+      as: [{ a: "a2", as: [] }]
+    }, { a: "a1", as: [{ a: "a2", as: [] }] })
+  })
+})


### PR DESCRIPTION
To rename one or more properties, you can utilize the `rename` API:

```ts
import * as Schema from "@effect/schema/Schema";

// Original Schema
const originalSchema = Schema.struct({ a: Schema.string, b: Schema.number });

// Renaming the "a" property to "c"
const renamedSchema = Schema.rename(originalSchema, { a: "c" });

Schema.parseSync(renamedSchema)({ a: "a", b: 1 }); // Output: { c: "a", b: 1 }
```

In the example above, we have an original schema with properties "a" and "b." Using the `rename` API, we create a new schema where we rename the "a" property to "c." The resulting schema, when used with `Schema.parseSync`, transforms the input object by renaming the specified property.
