### PR TITLE
Fix bug in property signature transformations when used for renaming …

### DIFF
--- a/.changeset/tender-glasses-pump.md
+++ b/.changeset/tender-glasses-pump.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Fix bug in property signature transformations when used for renaming (old key/value pair was not removed)

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -1123,10 +1123,9 @@ export const getFinalTransformation = (
                 Option.some(input[from]) :
                 Option.none()
             )
+            delete input[from]
             if (Option.isSome(o)) {
               input[to] = o.value
-            } else {
-              delete input[from]
             }
             return input
           }

--- a/test/Schema/PropertySignatureTransformations.test.ts
+++ b/test/Schema/PropertySignatureTransformations.test.ts
@@ -144,9 +144,9 @@ describe("Schema/PropertySignatureTransformations", () => {
         )
       )
     )
-    await Util.expectParseSuccess(transform, { a: 1 }, { b: 1 })
+    await Util.expectParseSuccess(transform, { a: 1 }, { b: 1 }, { onExcessProperty: "error" })
 
-    await Util.expectEncodeSuccess(transform, { b: 1 }, { a: 1 })
+    await Util.expectEncodeSuccess(transform, { b: 1 }, { a: 1 }, { onExcessProperty: "error" })
   })
 
   it("reversed default", async () => {


### PR DESCRIPTION
…(old key/value pair was not removed)