### PR TITLE
[WIP] add support for `Duration`

### DIFF
--- a/.changeset/slow-spiders-yell.md
+++ b/.changeset/slow-spiders-yell.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Added support for `Duration`

--- a/docs/modules/Schema.ts.md
+++ b/docs/modules/Schema.ts.md
@@ -27,6 +27,11 @@ Added in v1.0.0
   - [validDate](#validdate-1)
 - [Date transformations](#date-transformations)
   - [dateFromString](#datefromstring)
+- [Duration constructors](#duration-constructors)
+  - [Duration](#duration)
+  - [DurationFromSelf](#durationfromself)
+- [Duration transformations](#duration-transformations)
+  - [durationFromHrTime](#durationfromhrtime)
 - [Either transformations](#either-transformations)
   - [either](#either)
   - [eitherFromSelf](#eitherfromself)
@@ -426,6 +431,46 @@ A combinator that transforms a `string` into a valid `Date`.
 
 ```ts
 export declare const dateFromString: <I, A extends string>(self: Schema<I, A>) => Schema<I, Date>
+```
+
+Added in v1.0.0
+
+# Duration constructors
+
+## Duration
+
+A schema that transforms a `[number, number]` tuple into a `Duration`.
+
+**Signature**
+
+```ts
+export declare const Duration: Schema<readonly [seconds: number, nanos: number], Duration.Duration>
+```
+
+Added in v1.0.0
+
+## DurationFromSelf
+
+**Signature**
+
+```ts
+export declare const DurationFromSelf: Schema<Duration.Duration, Duration.Duration>
+```
+
+Added in v1.0.0
+
+# Duration transformations
+
+## durationFromHrTime
+
+A combinator that transforms a `[number, number]` tuple into a `Duration`.
+
+**Signature**
+
+```ts
+export declare const durationFromHrTime: <I, A extends readonly [seconds: number, nanos: number]>(
+  self: Schema<I, A>
+) => Schema<I, Duration.Duration>
 ```
 
 Added in v1.0.0

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -6,6 +6,7 @@ import * as BigInt_ from "effect/BigInt"
 import * as Brand from "effect/Brand"
 import * as Chunk from "effect/Chunk"
 import * as Data from "effect/Data"
+import * as Duration from "effect/Duration"
 import type * as Effect from "effect/Effect"
 import * as Either from "effect/Either"
 import * as Encoding from "effect/Encoding"
@@ -2809,6 +2810,88 @@ export const NonNegativeBigint: Schema<string, bigint> = bigint.pipe(
  * @since 1.0.0
  */
 export const BigintFromNumber: Schema<number, bigint> = bigintFromNumber(number)
+
+// ---------------------------------------------
+// Duration constructors
+// ---------------------------------------------
+
+/**
+ * @category Duration constructors
+ * @since 1.0.0
+ */
+export const DurationFromSelf: Schema<Duration.Duration> = declare(
+  [],
+  struct({}),
+  () => (u, _, ast) =>
+    !Duration.isDuration(u)
+      ? ParseResult.failure(ParseResult.type(ast, u))
+      : ParseResult.success(u),
+  {
+    [AST.IdentifierAnnotationId]: "Duration",
+    [Internal.PrettyHookId]: (): Pretty<Duration.Duration> =>
+      Duration.match({
+        onMillis: (_) => `Duration.millis(${_})`,
+        onNanos: (_) => `Duration.nanos(${_})`
+      }),
+    [Internal.ArbitraryHookId]: (): Arbitrary<Duration.Duration> => (fc) =>
+      fc.oneof(
+        fc.bigUint().map((_) => Duration.nanos(_)),
+        fc.bigUint().map((_) => Duration.micros(_)),
+        fc.maxSafeNat().map((_) => Duration.millis(_)),
+        fc.maxSafeNat().map((_) => Duration.seconds(_)),
+        fc.maxSafeNat().map((_) => Duration.minutes(_)),
+        fc.maxSafeNat().map((_) => Duration.hours(_)),
+        fc.maxSafeNat().map((_) => Duration.days(_)),
+        fc.maxSafeNat().map((_) => Duration.weeks(_))
+      ),
+    [Internal.EquivalenceHookId]: () => ReadonlyArray.getEquivalence(Equivalence.strict())
+  }
+)
+
+// ---------------------------------------------
+// Duration transformations
+// ---------------------------------------------
+
+/**
+ * A combinator that transforms a `[number, number]` tuple into a `Duration`.
+ *
+ * @category Duration transformations
+ * @since 1.0.0
+ */
+export const durationFromHrTime = <I, A extends readonly [seconds: number, nanos: number]>(
+  self: Schema<I, A>
+): Schema<I, Duration.Duration> =>
+  transform(
+    self,
+    DurationFromSelf,
+    ([s, n]) => Duration.nanos(BigInt(s) * BigInt(1e9) + BigInt(n)),
+    (n) => Duration.toHrTime(n),
+    { strict: false }
+  )
+
+const _Duration: Schema<readonly [seconds: number, nanos: number], Duration.Duration> =
+  durationFromHrTime(
+    tuple(
+      number.pipe(annotations({
+        [AST.TitleAnnotationId]: "seconds",
+        [AST.DescriptionAnnotationId]: "seconds"
+      })),
+      number.pipe(annotations({
+        [AST.TitleAnnotationId]: "nanos",
+        [AST.DescriptionAnnotationId]: "nanos"
+      }))
+    )
+  )
+
+export {
+  /**
+   * A schema that transforms a `[number, number]` tuple into a `Duration`.
+   *
+   * @category Duration constructors
+   * @since 1.0.0
+   */
+  _Duration as Duration
+}
 
 // ---------------------------------------------
 // Uint8Array constructors


### PR DESCRIPTION
@gcanti What kind of constructors and transformations would a user likely expect and use here?

Is it fine to only offer `hrtime` as the standard wire format and always transform that to `nanos` as the internal representation?

Do you see any downsides with that other than optimization (miniscule byte size overhead of the wire format for cases where would technically not be required)