### PR TITLE
improve JSON Schema output

### DIFF
--- a/.changeset/shy-eggs-march.md
+++ b/.changeset/shy-eggs-march.md
@@ -1,0 +1,11 @@
+---
+"@effect/schema": patch
+---
+
+improve JSON Schema output:
+
+- rename `dependencies` to `$defs`
+- remove `"type"` from const schemas
+- use `"oneOf"` for enums and add `"title"`s
+- add support for `record(pattern, number)`
+- add `"$comment"` properties

--- a/.changeset/shy-eggs-march.md
+++ b/.changeset/shy-eggs-march.md
@@ -8,4 +8,5 @@ improve JSON Schema output:
 - remove `"type"` from const schemas
 - use `"oneOf"` for enums and add `"title"`s
 - add support for `record(pattern, number)`
-- add `"$comment"` properties
+- add `"$id"` and `"$comment"` properties
+- literals should be converted to `enum` instead of `anyOf`, closes #579

--- a/docs/modules/JSONSchema.ts.md
+++ b/docs/modules/JSONSchema.ts.md
@@ -12,13 +12,13 @@ Added in v1.0.0
 
 <h2 class="text-delta">Table of contents</h2>
 
-- [JSON Schema](#json-schema)
+- [encoding](#encoding)
   - [from](#from)
   - [to](#to)
 
 ---
 
-# JSON Schema
+# encoding
 
 ## from
 

--- a/src/AST.ts
+++ b/src/AST.ts
@@ -311,6 +311,9 @@ export const createLiteral = (
  */
 export const isLiteral = (ast: AST): ast is Literal => ast._tag === "Literal"
 
+/** @internal */
+export const _null = createLiteral(null)
+
 /**
  * @category model
  * @since 1.0.0

--- a/src/JSONSchema.ts
+++ b/src/JSONSchema.ts
@@ -3,47 +3,70 @@
  */
 
 import * as Option from "effect/Option"
+import * as Predicate from "effect/Predicate"
 import * as ReadonlyArray from "effect/ReadonlyArray"
 import * as ReadonlyRecord from "effect/ReadonlyRecord"
 import * as AST from "./AST.js"
 import * as Parser from "./Parser.js"
-import type * as Schema from "./Schema.js"
+import * as Schema from "./Schema.js"
+
+interface JsonSchema7Any {
+  $id: "/schemas/any"
+}
+
+interface JsonSchema7Unknown {
+  $id: "/schemas/unknown"
+}
+
+interface JsonSchema7object {
+  $id: "/schemas/object"
+  oneOf: [
+    { type: "object" },
+    { type: "array" }
+  ]
+}
+
+interface JsonSchema7empty {
+  $id: "/schemas/{}"
+  oneOf: [
+    { type: "object" },
+    { type: "array" }
+  ]
+}
 
 interface JsonSchema7Ref {
   $ref: string
 }
 
-interface JsonSchema7Null {
-  type: "null"
+interface JsonSchema7Const {
+  const: AST.LiteralValue
 }
 
 interface JsonSchema7String {
   type: "string"
-  const?: string
-  enum?: Array<string>
   minLength?: number
   maxLength?: number
   pattern?: string
   description?: string
 }
 
-interface JsonSchema7Number {
-  type: "number" | "integer"
-  const?: number
-  enum?: Array<number>
+interface JsonSchema7Numeric {
   minimum?: number
   exclusiveMinimum?: number
   maximum?: number
   exclusiveMaximum?: number
 }
 
-interface JsonSchema7Boolean {
-  type: "boolean"
-  const?: boolean
+interface JsonSchema7Number extends JsonSchema7Numeric {
+  type: "number"
 }
 
-interface JsonSchema7Const {
-  const: string | number | boolean
+interface JsonSchema7Integer extends JsonSchema7Numeric {
+  type: "integer"
+}
+
+interface JsonSchema7Boolean {
+  type: "boolean"
 }
 
 interface JsonSchema7Array {
@@ -54,17 +77,20 @@ interface JsonSchema7Array {
   additionalItems?: JsonSchema7 | boolean
 }
 
-interface JsonSchema7Enum {
-  type: ["string", "number"]
-  enum: Array<string | number>
+interface JsonSchema7OneOf {
+  oneOf: Array<JsonSchema7>
+}
+
+interface JsonSchema7Enums {
+  $comment: "/schemas/enums"
+  oneOf: Array<{
+    title: string
+    const: string | number
+  }>
 }
 
 interface JsonSchema7AnyOf {
-  anyOf: ReadonlyArray<JsonSchema7>
-}
-
-interface JsonSchema7AllOf {
-  allOf: Array<JsonSchema7>
+  anyOf: Array<JsonSchema7>
 }
 
 interface JsonSchema7Object {
@@ -76,77 +102,88 @@ interface JsonSchema7Object {
 }
 
 type JsonSchema7 =
+  | JsonSchema7Any
+  | JsonSchema7Unknown
+  | JsonSchema7object
+  | JsonSchema7empty
   | JsonSchema7Ref
-  | JsonSchema7Null
+  | JsonSchema7Const
   | JsonSchema7String
   | JsonSchema7Number
+  | JsonSchema7Integer
   | JsonSchema7Boolean
-  | JsonSchema7Const
   | JsonSchema7Array
-  | JsonSchema7Enum
+  | JsonSchema7OneOf
+  | JsonSchema7Enums
   | JsonSchema7AnyOf
-  | JsonSchema7AllOf
   | JsonSchema7Object
 
 type JsonSchema7Top = JsonSchema7 & {
   $schema?: string
-  definitions?: Record<string, JsonSchema7>
+  $defs?: Record<string, JsonSchema7>
 }
 
 /**
- * @category JSON Schema
+ * @category encoding
  * @since 1.0.0
  */
 export const to = <I, A>(schema: Schema.Schema<I, A>): JsonSchema7Top => goTop(AST.to(schema.ast))
 
 /**
- * @category JSON Schema
+ * @category encoding
  * @since 1.0.0
  */
 export const from = <I, A>(schema: Schema.Schema<I, A>): JsonSchema7Top =>
   goTop(AST.from(schema.ast))
 
-const emptyObjectJsonSchema: JsonSchema7 = {
-  "anyOf": [
-    {
-      "type": "object",
-      "properties": {},
-      "required": []
-    },
+const anyJsonSchema: JsonSchema7 = { $id: "/schemas/any" }
+
+const unknownJsonSchema: JsonSchema7 = { $id: "/schemas/unknown" }
+
+const objectJsonSchema: JsonSchema7 = {
+  "$id": "/schemas/object",
+  "oneOf": [
+    { "type": "object" },
     { "type": "array" }
   ]
 }
 
-const anyJsonSchema: JsonSchema7 = {} as any
+const emptyJsonSchema: JsonSchema7 = {
+  "$id": "/schemas/{}",
+  "oneOf": [
+    { "type": "object" },
+    { "type": "array" }
+  ]
+}
 
 const $schema = "http://json-schema.org/draft-07/schema#"
 
 /** @internal */
 export const goTop = (ast: AST.AST): JsonSchema7Top => {
-  const definitions = {}
-  const jsonSchema = goWithMetaData(ast, definitions)
+  const $defs = {}
+  const jsonSchema = goWithMetaData(ast, $defs)
   const out: JsonSchema7Top = {
     $schema,
     ...jsonSchema
   }
-  if (!ReadonlyRecord.isEmptyRecord(definitions)) {
-    out.definitions = definitions
+  if (!ReadonlyRecord.isEmptyRecord($defs)) {
+    out.$defs = $defs
   }
   return out
 }
 
-const goWithIdentifier = (ast: AST.AST, definitions: Record<string, JsonSchema7>): JsonSchema7 => {
+const goWithIdentifier = (ast: AST.AST, $defs: Record<string, JsonSchema7>): JsonSchema7 => {
   const identifier = AST.getIdentifierAnnotation(ast)
   return Option.match(identifier, {
-    onNone: () => goWithMetaData(ast, definitions),
+    onNone: () => goWithMetaData(ast, $defs),
     onSome: (id) => {
-      if (!ReadonlyRecord.has(definitions, id)) {
-        const jsonSchema = goWithMetaData(ast, definitions)
-        if (!ReadonlyRecord.has(definitions, id)) {
-          definitions[id] = jsonSchema
+      if (!ReadonlyRecord.has($defs, id)) {
+        const jsonSchema = goWithMetaData(ast, $defs)
+        if (!ReadonlyRecord.has($defs, id)) {
+          $defs[id] = jsonSchema
         }
       }
-      return { $ref: `#/definitions/${id}` }
+      return { $ref: `#/$defs/${id}` }
     }
   })
 }
@@ -160,15 +197,17 @@ const getMetaData = (annotated: AST.Annotated) => {
   })
 }
 
-const goWithMetaData = (ast: AST.AST, definitions: Record<string, JsonSchema7>): JsonSchema7 => {
-  const jsonSchema = go(ast, definitions)
+const goWithMetaData = (ast: AST.AST, $defs: Record<string, JsonSchema7>): JsonSchema7 => {
+  const jsonSchema = go(ast, $defs)
   return {
     ...jsonSchema,
     ...getMetaData(ast)
   }
 }
 
-const go = (ast: AST.AST, definitions: Record<string, JsonSchema7>): JsonSchema7 => {
+const DEFINITION_PREFIX = "#/$defs/"
+
+const go = (ast: AST.AST, $defs: Record<string, JsonSchema7>): JsonSchema7 => {
   switch (ast._tag) {
     case "Declaration": {
       const annotation = AST.getJSONSchemaAnnotation(ast)
@@ -180,13 +219,17 @@ const go = (ast: AST.AST, definitions: Record<string, JsonSchema7>): JsonSchema7
       )
     }
     case "Literal": {
-      const type = typeof ast.literal
-      if (type === "bigint") {
-        throw new Error("cannot convert `bigint` to JSON Schema")
-      } else if (ast.literal === null) {
-        return { type: "null" }
+      const literal = ast.literal
+      if (literal === null) {
+        return { const: null }
+      } else if (Predicate.isString(literal)) {
+        return { const: literal }
+      } else if (Predicate.isNumber(literal)) {
+        return { const: literal }
+      } else if (Predicate.isBoolean(literal)) {
+        return { const: literal }
       }
-      return { type, const: ast.literal } as any
+      throw new Error("cannot convert `bigint` to JSON Schema")
     }
     case "UniqueSymbol":
       throw new Error("cannot convert a unique symbol to JSON Schema")
@@ -197,10 +240,11 @@ const go = (ast: AST.AST, definitions: Record<string, JsonSchema7>): JsonSchema7
     case "NeverKeyword":
       throw new Error("cannot convert `never` to JSON Schema")
     case "UnknownKeyword":
+      return { ...unknownJsonSchema }
     case "AnyKeyword":
-      return anyJsonSchema
+      return { ...anyJsonSchema }
     case "ObjectKeyword":
-      return emptyObjectJsonSchema
+      return { ...objectJsonSchema }
     case "StringKeyword":
       return { type: "string" }
     case "NumberKeyword":
@@ -212,10 +256,10 @@ const go = (ast: AST.AST, definitions: Record<string, JsonSchema7>): JsonSchema7
     case "SymbolKeyword":
       throw new Error("cannot convert `symbol` to JSON Schema")
     case "Tuple": {
-      const elements = ast.elements.map((e) => goWithIdentifier(e.type, definitions))
+      const elements = ast.elements.map((e) => goWithIdentifier(e.type, $defs))
       const rest = Option.map(
         ast.rest,
-        ReadonlyArray.map((ast) => goWithIdentifier(ast, definitions))
+        ReadonlyArray.map((ast) => goWithIdentifier(ast, $defs))
       )
       const output: JsonSchema7Array = { type: "array" }
       // ---------------------------------------------
@@ -257,31 +301,48 @@ const go = (ast: AST.AST, definitions: Record<string, JsonSchema7>): JsonSchema7
     }
     case "TypeLiteral": {
       if (ast.propertySignatures.length === 0 && ast.indexSignatures.length === 0) {
-        return emptyObjectJsonSchema
+        return { ...emptyJsonSchema }
       }
       let additionalProperties: JsonSchema7 | undefined = undefined
       let patternProperties: Record<string, JsonSchema7> | undefined = undefined
       for (const is of ast.indexSignatures) {
         const parameter = is.parameter
         switch (parameter._tag) {
-          case "StringKeyword":
-            additionalProperties = goWithIdentifier(is.type, definitions)
+          case "StringKeyword": {
+            additionalProperties = goWithIdentifier(is.type, $defs)
             break
-          case "TemplateLiteral":
+          }
+          case "TemplateLiteral": {
             patternProperties = {
               [Parser.getTemplateLiteralRegex(parameter).source]: goWithIdentifier(
                 is.type,
-                definitions
+                $defs
               )
             }
             break
+          }
+          case "Refinement": {
+            const annotation = AST.getJSONSchemaAnnotation(parameter)
+            if (
+              Option.isSome(annotation) && "pattern" in annotation.value &&
+              Predicate.isString(annotation.value.pattern)
+            ) {
+              patternProperties = {
+                [annotation.value.pattern]: goWithIdentifier(
+                  is.type,
+                  $defs
+                )
+              }
+              break
+            }
+            throw new Error(`Unsupported index signature parameter ${parameter._tag}`)
+          }
           case "SymbolKeyword":
-          case "Refinement":
             throw new Error(`Unsupported index signature parameter ${parameter._tag}`)
         }
       }
       const propertySignatures = ast.propertySignatures.map((ps) => {
-        return { ...goWithIdentifier(ps.type, definitions), ...getMetaData(ps) }
+        return { ...goWithIdentifier(ps.type, $defs), ...getMetaData(ps) }
       })
       const output: JsonSchema7Object = {
         type: "object",
@@ -319,31 +380,15 @@ const go = (ast: AST.AST, definitions: Record<string, JsonSchema7>): JsonSchema7
       return output
     }
     case "Union":
-      return { "anyOf": ast.types.map((ast) => goWithIdentifier(ast, definitions)) }
+      return { anyOf: ast.types.map((ast) => goWithIdentifier(ast, $defs)) }
     case "Enums": {
-      const enums: Array<any> = []
-      const types = {
-        string: false,
-        number: false
-      }
-      for (const [_, value] of ast.enums) {
-        if (typeof value === "string") {
-          types.string = true
-        } else {
-          types.number = true
-        }
-        enums.push(value)
-      }
-      if (types.string && types.number) {
-        return { type: ["string", "number"], enum: enums }
-      } else if (types.string) {
-        return { type: "string", enum: enums }
-      } else {
-        return { type: "number", enum: enums }
+      return {
+        $comment: "/schemas/enums",
+        oneOf: ast.enums.map((e) => ({ title: e[0], const: e[1] }))
       }
     }
     case "Refinement": {
-      const from = goWithIdentifier(ast.from, definitions)
+      const from = goWithIdentifier(ast.from, $defs)
       const annotation = AST.getJSONSchemaAnnotation(ast)
       if (Option.isSome(annotation)) {
         return { ...from, ...annotation.value }
@@ -368,14 +413,118 @@ const go = (ast: AST.AST, definitions: Record<string, JsonSchema7>): JsonSchema7
         )
       }
       const id = identifier.value
-      if (!ReadonlyRecord.has(definitions, id)) {
-        definitions[id] = anyJsonSchema
-        const jsonSchema = goWithIdentifier(ast.f(), definitions)
-        definitions[id] = jsonSchema
+      if (!ReadonlyRecord.has($defs, id)) {
+        $defs[id] = anyJsonSchema
+        const jsonSchema = goWithIdentifier(ast.f(), $defs)
+        $defs[id] = jsonSchema
       }
-      return { $ref: `#/definitions/${id}` }
+      return { $ref: `${DEFINITION_PREFIX}${id}` }
     }
     case "Transform":
       throw new Error("cannot build a JSON Schema for transformations")
   }
+}
+
+/** @internal */
+export const decode = <A>(schema: JsonSchema7Top): Schema.Schema<A> =>
+  Schema.make(decodeAST(schema, schema.$defs))
+
+const emptyTypeLiteralAST = AST.createTypeLiteral([], [])
+
+const decodeAST = (schema: JsonSchema7, $defs: JsonSchema7Top["$defs"]): AST.AST => {
+  if ("$id" in schema) {
+    switch (schema.$id) {
+      case "/schemas/any":
+        return AST.anyKeyword
+      case "/schemas/unknown":
+        return AST.unknownKeyword
+      case "/schemas/object":
+        return AST.objectKeyword
+      case "/schemas/{}":
+        return emptyTypeLiteralAST
+    }
+  } else if ("const" in schema) {
+    return AST.createLiteral(schema.const)
+  } else if ("type" in schema) {
+    const type = schema.type
+    if (type === "string") {
+      return AST.stringKeyword
+    } else if (type === "number") {
+      return AST.numberKeyword
+    } else if (type === "integer") {
+      return AST.numberKeyword
+    } else if (type === "boolean") {
+      return AST.booleanKeyword
+    } else if (type === "array") {
+      if (schema.items) {
+        if (Array.isArray(schema.items)) {
+          const minItems = schema.minItems ?? -1
+          const rest: AST.Tuple["rest"] =
+            schema.additionalItems && !Predicate.isBoolean(schema.additionalItems)
+              ? Option.some([decodeAST(schema.additionalItems, $defs)])
+              : Option.none()
+          return AST.createTuple(
+            schema.items.map((item, i) => AST.createElement(decodeAST(item, $defs), i >= minItems)),
+            rest,
+            true
+          )
+        } else {
+          return AST.createTuple([], Option.some([decodeAST(schema.items, $defs)]), true)
+        }
+      } else {
+        return AST.createTuple([], Option.none(), true)
+      }
+    } else if (type === "object") {
+      const required = schema.required || []
+      const propertySignatures: Array<AST.PropertySignature> = []
+      const indexSignatures: Array<AST.IndexSignature> = []
+      for (const name in schema.properties) {
+        propertySignatures.push(
+          AST.createPropertySignature(
+            name,
+            decodeAST(schema.properties[name], $defs),
+            !required.includes(name),
+            true
+          )
+        )
+      }
+      if (schema.additionalProperties && !Predicate.isBoolean(schema.additionalProperties)) {
+        indexSignatures.push(
+          AST.createIndexSignature(
+            AST.stringKeyword,
+            decodeAST(schema.additionalProperties, $defs),
+            true
+          )
+        )
+      }
+      if (schema.patternProperties) {
+        for (const pattern in schema.patternProperties) {
+          indexSignatures.push(
+            AST.createIndexSignature(
+              Schema.string.pipe(Schema.pattern(new RegExp(pattern))).ast,
+              decodeAST(schema.patternProperties[pattern], $defs),
+              true
+            )
+          )
+        }
+      }
+      return AST.createTypeLiteral(propertySignatures, indexSignatures)
+    }
+  } else if ("anyOf" in schema) {
+    return AST.createUnion(schema.anyOf.map((s) => decodeAST(s, $defs)))
+  } else if ("oneOf" in schema) {
+    if ("$comment" in schema && schema.$comment === "/schemas/enums") {
+      return AST.createEnums(schema.oneOf.map((e) => [e.title, e.const]))
+    }
+    return AST.createUnion(schema.oneOf.map((s) => decodeAST(s, $defs)))
+  } else if ("$ref" in schema) {
+    if ($defs) {
+      const id = schema.$ref.substring(DEFINITION_PREFIX.length)
+      if (id in $defs) {
+        return decodeAST($defs[id], $defs)
+      }
+    }
+    throw new Error(`cannot find $ref: ${schema.$ref}`)
+  }
+  throw new Error(`cannot decode: ${JSON.stringify(schema, null, 2)}`)
 }

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -449,7 +449,7 @@ const _undefined: Schema<undefined> = make(AST.undefinedKeyword)
 
 const _void: Schema<void> = make(AST.voidKeyword)
 
-const _null: Schema<null> = make(AST.createLiteral(null))
+const _null: Schema<null> = make(AST._null)
 
 export {
   /**


### PR DESCRIPTION
- rename `dependencies` to `$defs`
- remove `"type"` from const schemas
- use `"oneOf"` for enums and add `"title"`s
- add support for `record(pattern, number)`
- add `"$id"` and `"$comment"` properties
- literals should be converted to `enum` instead of `anyOf`, closes #579
