### PR TITLE
Parser: should use the original ast to generate a more informative error m…

### DIFF
--- a/.changeset/smart-bags-add.md
+++ b/.changeset/smart-bags-add.md
@@ -2,4 +2,4 @@
 "@effect/schema": patch
 ---
 
-Parser: should use annotations to generate a more informative error message when an incorrect data type is provided
+Parser: should use the original ast to generate a more informative error message when an incorrect data type is provided

--- a/.changeset/smart-bags-add.md
+++ b/.changeset/smart-bags-add.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+Parser: should use annotations to generate a more informative error message when an incorrect data type is provided

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -359,7 +359,7 @@ const go = (ast: AST.AST, isDecoding: boolean): Parser<any, any> => {
       }
       return (input: unknown, options) => {
         if (!Array.isArray(input)) {
-          return ParseResult.failure(ParseResult.type(unknownArray, input))
+          return ParseResult.failure(ParseResult.type(ast, input))
         }
         const allErrors = options?.errors === "all"
         const es: Array<[number, ParseResult.ParseErrors]> = []
@@ -603,7 +603,7 @@ const go = (ast: AST.AST, isDecoding: boolean): Parser<any, any> => {
 
       return (input: unknown, options) => {
         if (!Predicate.isRecord(input)) {
-          return ParseResult.failure(ParseResult.type(unknownRecord, input))
+          return ParseResult.failure(ParseResult.type(ast, input))
         }
         const allErrors = options?.errors === "all"
         const es: Array<[number, ParseResult.ParseErrors]> = []
@@ -842,7 +842,7 @@ const go = (ast: AST.AST, isDecoding: boolean): Parser<any, any> => {
               }
             }
           } else {
-            es.push([stepKey++, ParseResult.type(unknownRecord, input)])
+            es.push([stepKey++, ParseResult.type(ast, input)])
           }
         }
         if (searchTree.otherwise.length > 0) {
@@ -1038,17 +1038,6 @@ const handleForbidden = <A>(
     ? conditional
     : ParseResult.failure(ParseResult.forbidden)
 }
-
-const unknownArray = AST.createTuple([], Option.some([AST.unknownKeyword]), true, {
-  [AST.DescriptionAnnotationId]: "a generic array"
-})
-
-const unknownRecord = AST.createTypeLiteral([], [
-  AST.createIndexSignature(AST.stringKeyword, AST.unknownKeyword, true),
-  AST.createIndexSignature(AST.symbolKeyword, AST.unknownKeyword, true)
-], {
-  [AST.DescriptionAnnotationId]: "a generic object"
-})
 
 const mutableAppend = <A>(self: Array<A>, a: A): ReadonlyArray.NonEmptyReadonlyArray<A> => {
   self.push(a)

--- a/src/TreeFormatter.ts
+++ b/src/TreeFormatter.ts
@@ -97,7 +97,7 @@ export const formatExpected = (ast: AST.AST): string => {
     case "UniqueSymbol":
       return Option.getOrElse(getExpected(ast), () => formatActual(ast.symbol))
     case "Union":
-      return ast.types.map(formatExpected).join(" or ")
+      return [...new Set(ast.types.map(formatExpected))].join(" or ")
     case "TemplateLiteral":
       return Option.getOrElse(getExpected(ast), () => formatTemplateLiteral(ast))
     case "Tuple":

--- a/test/Chunk/chunk.test.ts
+++ b/test/Chunk/chunk.test.ts
@@ -16,7 +16,7 @@ describe("Chunk/chunk", () => {
     await Util.expectParseFailure(
       schema,
       null,
-      `Expected a generic array, actual null`
+      `Expected <anonymous tuple or array schema>, actual null`
     )
     await Util.expectParseFailure(schema, [1, "a"], `/1 Expected number, actual "a"`)
   })

--- a/test/ReadonlyMap/readonlyMap.test.ts
+++ b/test/ReadonlyMap/readonlyMap.test.ts
@@ -19,7 +19,7 @@ describe("ReadonlyMap/readonlyMap", () => {
     await Util.expectParseFailure(
       schema,
       null,
-      `Expected a generic array, actual null`
+      `Expected <anonymous tuple or array schema>, actual null`
     )
     await Util.expectParseFailure(
       schema,

--- a/test/ReadonlySet/readonlySet.test.ts
+++ b/test/ReadonlySet/readonlySet.test.ts
@@ -15,7 +15,7 @@ describe("ReadonlySet/readonlySet", () => {
     await Util.expectParseFailure(
       schema,
       null,
-      `Expected a generic array, actual null`
+      `Expected <anonymous tuple or array schema>, actual null`
     )
     await Util.expectParseFailure(schema, [1, "a"], `/1 Expected number, actual "a"`)
   })

--- a/test/Schema/lazy.test.ts
+++ b/test/Schema/lazy.test.ts
@@ -22,7 +22,7 @@ describe("Schema/lazy", () => {
       await Util.expectParseFailure(
         schema,
         null,
-        `Expected a generic object, actual null`
+        `Expected <anonymous type literal schema>, actual null`
       )
       await Util.expectParseFailure(
         schema,
@@ -32,7 +32,7 @@ describe("Schema/lazy", () => {
       await Util.expectParseFailure(
         schema,
         { a: "a1", as: [{ a: "a2", as: [1] }] },
-        "/as /0 /as /0 Expected a generic object, actual 1"
+        "/as /0 /as /0 Expected <anonymous type literal schema>, actual 1"
       )
     })
 

--- a/test/Schema/omit.test.ts
+++ b/test/Schema/omit.test.ts
@@ -13,7 +13,7 @@ describe("Schema/omit", () => {
     await Util.expectParseFailure(
       schema,
       null,
-      "Expected a generic object, actual null"
+      "Expected <anonymous type literal schema>, actual null"
     )
     await Util.expectParseFailure(schema, { [a]: "a" }, `/b is missing`)
     await Util.expectParseFailure(
@@ -30,7 +30,11 @@ describe("Schema/omit", () => {
     await Util.expectParseSuccess(schema, { a: "a", b: "1" }, { a: "a", b: 1 })
     await Util.expectParseSuccess(schema, { b: "1" }, { b: 1 })
 
-    await Util.expectParseFailure(schema, null, "Expected a generic object, actual null")
+    await Util.expectParseFailure(
+      schema,
+      null,
+      "Expected <anonymous type literal schema>, actual null"
+    )
     await Util.expectParseFailure(schema, { a: "a" }, `/b is missing`)
   })
 

--- a/test/Schema/partial.test.ts
+++ b/test/Schema/partial.test.ts
@@ -101,7 +101,7 @@ describe("Schema/partial", () => {
     await Util.expectParseFailure(
       schema,
       { a: 1 },
-      "/a union member: Expected a generic object, actual 1, union member: Expected null, actual 1"
+      "/a union member: Expected <anonymous type literal schema>, actual 1, union member: Expected null, actual 1"
     )
   })
 

--- a/test/Schema/pick.test.ts
+++ b/test/Schema/pick.test.ts
@@ -10,7 +10,11 @@ describe("Schema/pick", () => {
     )
     await Util.expectParseSuccess(schema, { [a]: "a", b: "1" }, { [a]: "a", b: 1 })
 
-    await Util.expectParseFailure(schema, null, "Expected a generic object, actual null")
+    await Util.expectParseFailure(
+      schema,
+      null,
+      "Expected <anonymous type literal schema>, actual null"
+    )
     await Util.expectParseFailure(schema, { [a]: "a" }, `/b is missing`)
     await Util.expectParseFailure(
       schema,
@@ -26,7 +30,11 @@ describe("Schema/pick", () => {
     await Util.expectParseSuccess(schema, { a: "a", b: "1" }, { a: "a", b: 1 })
     await Util.expectParseSuccess(schema, { b: "1" }, { b: 1 })
 
-    await Util.expectParseFailure(schema, null, "Expected a generic object, actual null")
+    await Util.expectParseFailure(
+      schema,
+      null,
+      "Expected <anonymous type literal schema>, actual null"
+    )
     await Util.expectParseFailure(schema, { a: "a" }, `/b is missing`)
   })
 

--- a/test/Schema/record.test.ts
+++ b/test/Schema/record.test.ts
@@ -18,7 +18,7 @@ describe("Schema/record", () => {
       await Util.expectParseFailure(
         schema,
         [],
-        "Expected a generic object, actual []"
+        "Expected <anonymous type literal schema>, actual []"
       )
       await Util.expectParseFailure(
         schema,
@@ -48,7 +48,7 @@ describe("Schema/record", () => {
       await Util.expectParseFailure(
         schema,
         [],
-        "Expected a generic object, actual []"
+        "Expected <anonymous type literal schema>, actual []"
       )
       await Util.expectParseFailure(
         schema,

--- a/test/Schema/struct.test.ts
+++ b/test/Schema/struct.test.ts
@@ -9,6 +9,21 @@ describe("Schema/struct", () => {
   })
 
   describe("decoding", () => {
+    it("should use annotations to generate a more informative error message when an incorrect data type is provided", async () => {
+      const schema = S.struct({}).pipe(S.identifier("MyDataType"))
+      await Util.expectParseFailure(
+        schema,
+        null,
+        `Expected MyDataType, actual null`
+      )
+      await Util.expectParseFailureTree(
+        schema,
+        null,
+        `error(s) found
+└─ Expected MyDataType, actual null`
+      )
+    })
+
     it("empty", async () => {
       const schema = S.struct({})
       await Util.expectParseSuccess(schema, {})
@@ -29,7 +44,7 @@ describe("Schema/struct", () => {
       await Util.expectParseFailure(
         schema,
         null,
-        `Expected a generic object, actual null`
+        `Expected <anonymous type literal schema>, actual null`
       )
       await Util.expectParseFailure(schema, {}, "/a is missing")
       await Util.expectParseFailure(
@@ -53,7 +68,7 @@ describe("Schema/struct", () => {
       await Util.expectParseFailure(
         schema,
         null,
-        `Expected a generic object, actual null`
+        `Expected <anonymous type literal schema>, actual null`
       )
       await Util.expectParseFailure(schema, {}, "/a is missing")
       await Util.expectParseFailure(
@@ -77,7 +92,7 @@ describe("Schema/struct", () => {
       await Util.expectParseFailure(
         schema,
         null,
-        `Expected a generic object, actual null`
+        `Expected <anonymous type literal schema>, actual null`
       )
       await Util.expectParseFailure(
         schema,
@@ -106,7 +121,7 @@ describe("Schema/struct", () => {
       await Util.expectParseFailure(
         schema,
         null,
-        `Expected a generic object, actual null`
+        `Expected <anonymous type literal schema>, actual null`
       )
       await Util.expectParseFailure(
         schema,

--- a/test/Schema/tuple.test.ts
+++ b/test/Schema/tuple.test.ts
@@ -25,6 +25,21 @@ describe("Schema/tuple", () => {
   })
 
   describe("decoding", () => {
+    it("should use annotations to generate a more informative error message when an incorrect data type is provided", async () => {
+      const schema = S.tuple().pipe(S.identifier("MyDataType"))
+      await Util.expectParseFailure(
+        schema,
+        null,
+        `Expected MyDataType, actual null`
+      )
+      await Util.expectParseFailureTree(
+        schema,
+        null,
+        `error(s) found
+└─ Expected MyDataType, actual null`
+      )
+    })
+
     it("empty", async () => {
       const schema = S.tuple()
       await Util.expectParseSuccess(schema, [])
@@ -32,12 +47,12 @@ describe("Schema/tuple", () => {
       await Util.expectParseFailure(
         schema,
         null,
-        `Expected a generic array, actual null`
+        `Expected <anonymous tuple or array schema>, actual null`
       )
       await Util.expectParseFailure(
         schema,
         {},
-        `Expected a generic array, actual {}`
+        `Expected <anonymous tuple or array schema>, actual {}`
       )
       await Util.expectParseFailure(schema, [undefined], `/0 is unexpected`)
       await Util.expectParseFailure(schema, [1], `/0 is unexpected`)
@@ -50,7 +65,7 @@ describe("Schema/tuple", () => {
       await Util.expectParseFailure(
         schema,
         null,
-        `Expected a generic array, actual null`
+        `Expected <anonymous tuple or array schema>, actual null`
       )
       await Util.expectParseFailure(schema, [], `/0 is missing`)
       await Util.expectParseFailure(
@@ -70,7 +85,7 @@ describe("Schema/tuple", () => {
       await Util.expectParseFailure(
         schema,
         null,
-        `Expected a generic array, actual null`
+        `Expected <anonymous tuple or array schema>, actual null`
       )
       await Util.expectParseFailure(schema, [], `/0 is missing`)
       await Util.expectParseFailure(
@@ -89,7 +104,7 @@ describe("Schema/tuple", () => {
       await Util.expectParseFailure(
         schema,
         null,
-        `Expected a generic array, actual null`
+        `Expected <anonymous tuple or array schema>, actual null`
       )
       await Util.expectParseFailure(
         schema,
@@ -108,7 +123,7 @@ describe("Schema/tuple", () => {
       await Util.expectParseFailure(
         schema,
         null,
-        `Expected a generic array, actual null`
+        `Expected <anonymous tuple or array schema>, actual null`
       )
       await Util.expectParseFailure(
         schema,

--- a/test/Schema/union.test.ts
+++ b/test/Schema/union.test.ts
@@ -4,6 +4,27 @@ import { describe, it } from "vitest"
 
 describe("Schema/literal", () => {
   describe("decoding", () => {
+    it("should use annotations to generate a more informative error message when an incorrect data type is provided", async () => {
+      const schema = S.union(
+        S.struct({}).pipe(S.identifier("MyDataType1")),
+        S.struct({}).pipe(S.identifier("MyDataType2"))
+      )
+      await Util.expectParseFailure(
+        schema,
+        null,
+        `union member: Expected MyDataType1, actual null, union member: Expected MyDataType2, actual null`
+      )
+      await Util.expectParseFailureTree(
+        schema,
+        null,
+        `error(s) found
+├─ union member
+│  └─ Expected MyDataType1, actual null
+└─ union member
+   └─ Expected MyDataType2, actual null`
+      )
+    })
+
     it("empty union", async () => {
       const schema = S.union()
       await Util.expectParseFailure(schema, 1, "Expected never, actual 1")
@@ -17,7 +38,7 @@ describe("Schema/literal", () => {
       await Util.expectParseFailure(
         schema,
         null,
-        "Expected a generic object, actual null"
+        "Expected <anonymous type literal schema>, actual null"
       )
       await Util.expectParseFailure(schema, {}, "/a is missing, /b is missing")
       await Util.expectParseFailure(
@@ -37,7 +58,7 @@ describe("Schema/literal", () => {
       await Util.expectParseFailure(
         schema,
         null,
-        "Expected a generic object, actual null"
+        "Expected <anonymous type literal schema>, actual null"
       )
       await Util.expectParseFailure(schema, {}, "/category is missing, /tag is missing")
       await Util.expectParseFailure(


### PR DESCRIPTION
…essage when an incorrect data type is provided