### PR TITLE
updated BigDecimal Pretty instance

### DIFF
--- a/.changeset/chilly-cobras-jump.md
+++ b/.changeset/chilly-cobras-jump.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+updated BigDecimal Pretty instance

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -3535,7 +3535,7 @@ export const readonlySet = <I, A>(item: Schema<I, A>): Schema<ReadonlyArray<I>, 
 // ---------------------------------------------
 
 const bigDecimalPretty = (): Pretty<BigDecimal.BigDecimal> => (val) =>
-  `BigDecimal(${BigDecimal.toString(BigDecimal.normalize(val))})`
+  BigDecimal.toString(BigDecimal.normalize(val))
 
 const bigDecimalArbitrary = (): Arbitrary<BigDecimal.BigDecimal> => (fc) =>
   fc.tuple(fc.bigInt(), fc.integer()).map(([value, scale]) => BigDecimal.make(value, scale))

--- a/test/BigDecimal/BigDecimalFromSelf.test.ts
+++ b/test/BigDecimal/BigDecimalFromSelf.test.ts
@@ -36,9 +36,9 @@ describe("BigDecimal/BigDecimalFromSelf", () => {
     const schema = S.BigDecimalFromSelf
     const pretty = Pretty.to(schema)
 
-    expect(pretty(BigDecimal.fromNumber(123))).toEqual("BigDecimal(123)")
-    expect(pretty(BigDecimal.unsafeFromString("123.100"))).toEqual("BigDecimal(123.1)")
-    expect(pretty(BigDecimal.unsafeFromString(""))).toEqual("BigDecimal(0)")
+    expect(pretty(BigDecimal.fromNumber(123))).toEqual("123")
+    expect(pretty(BigDecimal.unsafeFromString("123.100"))).toEqual("123.1")
+    expect(pretty(BigDecimal.unsafeFromString(""))).toEqual("0")
   })
 
   it("equivalence", () => {


### PR DESCRIPTION
There is an inconsistency with how BigDecimals are rendered to a string. @fubhy Do you think we should wrap the string in `"BigDecimal()"` or just render it to a string directly? I'm leaning towards rendering it directly to a string.. 