### PR TITLE
TreeFormatter: enhance `formatActual` for data types with a custom `t…

### DIFF
--- a/.changeset/twenty-birds-repeat.md
+++ b/.changeset/twenty-birds-repeat.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+TreeFormatter: enhance `formatActual` for data types with a custom `toString` implementation, closes #600

--- a/src/TreeFormatter.ts
+++ b/src/TreeFormatter.ts
@@ -44,20 +44,23 @@ const draw = (indentation: string, forest: Forest<string>): string => {
 
 /** @internal */
 export const formatActual = (actual: unknown): string => {
-  if (
-    actual == null || Predicate.isNumber(actual) || Predicate.isSymbol(actual) ||
-    Predicate.isDate(actual)
+  if (Predicate.isString(actual)) {
+    return JSON.stringify(actual)
+  } else if (
+    Predicate.isNumber(actual)
+    || actual == null
+    || Predicate.isBoolean(actual)
+    || Predicate.isSymbol(actual)
+    || Predicate.isDate(actual)
   ) {
     return String(actual)
-  }
-  if (Predicate.isBigInt(actual)) {
+  } else if (Predicate.isBigInt(actual)) {
     return String(actual) + "n"
-  }
-  if (
-    !Array.isArray(actual) &&
-    Predicate.hasProperty(actual, "toString") &&
-    Predicate.isFunction(actual["toString"]) &&
-    actual["toString"] !== Object.prototype.toString
+  } else if (
+    !Array.isArray(actual)
+    && Predicate.hasProperty(actual, "toString")
+    && Predicate.isFunction(actual["toString"])
+    && actual["toString"] !== Object.prototype.toString
   ) {
     return actual["toString"]()
   }

--- a/src/TreeFormatter.ts
+++ b/src/TreeFormatter.ts
@@ -3,6 +3,7 @@
  */
 
 import * as Option from "effect/Option"
+import * as Predicate from "effect/Predicate"
 import type { NonEmptyReadonlyArray } from "effect/ReadonlyArray"
 import * as AST from "./AST.js"
 import type { ParseErrors, Type } from "./ParseResult.js"
@@ -44,13 +45,21 @@ const draw = (indentation: string, forest: Forest<string>): string => {
 /** @internal */
 export const formatActual = (actual: unknown): string => {
   if (
-    actual === undefined || actual === null || typeof actual === "number" ||
-    typeof actual === "symbol" || actual instanceof Date
+    actual == null || Predicate.isNumber(actual) || Predicate.isSymbol(actual) ||
+    Predicate.isDate(actual)
   ) {
     return String(actual)
   }
-  if (typeof actual === "bigint") {
+  if (Predicate.isBigInt(actual)) {
     return String(actual) + "n"
+  }
+  if (
+    !Array.isArray(actual) &&
+    Predicate.hasProperty(actual, "toString") &&
+    Predicate.isFunction(actual["toString"]) &&
+    actual["toString"] !== Object.prototype.toString
+  ) {
+    return actual["toString"]()
   }
   try {
     return JSON.stringify(actual)

--- a/test/BigDecimal/BigDecimal.test.ts
+++ b/test/BigDecimal/BigDecimal.test.ts
@@ -25,7 +25,7 @@ describe("BigDecimal/BigDecimal", () => {
     await Util.expectParseFailure(
       schema,
       "abc",
-      "Expected string <-> BigDecimal, actual \"abc\""
+      `Expected string <-> BigDecimal, actual "abc"`
     )
   })
 

--- a/test/BigDecimal/BigDecimalFromNumber.test.ts
+++ b/test/BigDecimal/BigDecimalFromNumber.test.ts
@@ -25,7 +25,7 @@ describe("BigDecimal/BigDecimalFromNumber", () => {
     await Util.expectParseFailure(
       schema,
       "abc",
-      "Expected number, actual \"abc\""
+      `Expected number, actual "abc"`
     )
   })
 

--- a/test/BigDecimal/betweenBigDecimal.test.ts
+++ b/test/BigDecimal/betweenBigDecimal.test.ts
@@ -12,7 +12,7 @@ describe("BigDecimal/between", () => {
     await Util.expectParseFailure(
       schema,
       "2",
-      `Expected a BigDecimal between -1 and 1, actual {"_id":"BigDecimal","value":"2","scale":0}`
+      `Expected a BigDecimal between -1 and 1, actual 2`
     )
     await Util.expectParseSuccess(schema, "0", BigDecimal.make(0n, 0))
     await Util.expectParseSuccess(

--- a/test/BigDecimal/greaterThanBigDecimal.test.ts
+++ b/test/BigDecimal/greaterThanBigDecimal.test.ts
@@ -11,12 +11,12 @@ describe("BigDecimal/greaterThanBigDecimal", () => {
     await Util.expectParseFailure(
       schema,
       "0",
-      "Expected a BigDecimal greater than 10, actual {\"_id\":\"BigDecimal\",\"value\":\"0\",\"scale\":0}"
+      "Expected a BigDecimal greater than 10, actual 0"
     )
     await Util.expectParseFailure(
       schema,
       "10",
-      "Expected a BigDecimal greater than 10, actual {\"_id\":\"BigDecimal\",\"value\":\"1\",\"scale\":-1}"
+      "Expected a BigDecimal greater than 10, actual 10"
     )
   })
 

--- a/test/BigDecimal/greaterThanOrEqualToBigDecimal.test.ts
+++ b/test/BigDecimal/greaterThanOrEqualToBigDecimal.test.ts
@@ -11,7 +11,7 @@ describe("BigDecimal/greaterThanOrEqualToBigDecimal", () => {
     await Util.expectParseFailure(
       schema,
       "0",
-      "Expected a BigDecimal greater than or equal to 10, actual {\"_id\":\"BigDecimal\",\"value\":\"0\",\"scale\":0}"
+      "Expected a BigDecimal greater than or equal to 10, actual 0"
     )
     await Util.expectParseSuccess(
       schema,

--- a/test/BigDecimal/lessThanBigDecimal.test.ts
+++ b/test/BigDecimal/lessThanBigDecimal.test.ts
@@ -11,12 +11,12 @@ describe("BigDecimal/lessThanBigDecimal", () => {
     await Util.expectParseFailure(
       schema,
       "5",
-      "Expected a BigDecimal less than 5, actual {\"_id\":\"BigDecimal\",\"value\":\"5\",\"scale\":0}"
+      "Expected a BigDecimal less than 5, actual 5"
     )
     await Util.expectParseFailure(
       schema,
       "6",
-      "Expected a BigDecimal less than 5, actual {\"_id\":\"BigDecimal\",\"value\":\"6\",\"scale\":0}"
+      "Expected a BigDecimal less than 5, actual 6"
     )
   })
 

--- a/test/BigDecimal/lessThanOrEqualToBigDecimal.test.ts
+++ b/test/BigDecimal/lessThanOrEqualToBigDecimal.test.ts
@@ -16,7 +16,7 @@ describe("BigDecimal/lessThanOrEqualToBigDecimal", () => {
     await Util.expectParseFailure(
       schema,
       "6",
-      "Expected a BigDecimal less than or equal to 5, actual {\"_id\":\"BigDecimal\",\"value\":\"6\",\"scale\":0}"
+      "Expected a BigDecimal less than or equal to 5, actual 6"
     )
   })
 

--- a/test/BigDecimal/negativeBigDecimal.test.ts
+++ b/test/BigDecimal/negativeBigDecimal.test.ts
@@ -10,12 +10,12 @@ describe("BigDecimal/negativeBigDecimal", () => {
     await Util.expectParseFailure(
       schema,
       BigDecimal.make(0n, 0),
-      "Expected a negative BigDecimal, actual {\"_id\":\"BigDecimal\",\"value\":\"0\",\"scale\":0}"
+      "Expected a negative BigDecimal, actual 0"
     )
     await Util.expectParseFailure(
       schema,
       BigDecimal.make(2n, 0),
-      "Expected a negative BigDecimal, actual {\"_id\":\"BigDecimal\",\"value\":\"2\",\"scale\":0}"
+      "Expected a negative BigDecimal, actual 2"
     )
     await Util.expectParseSuccess(
       schema,

--- a/test/BigDecimal/nonNegativeBigDecimal.test.ts
+++ b/test/BigDecimal/nonNegativeBigDecimal.test.ts
@@ -15,7 +15,7 @@ describe("BigDecimal/nonNegativeBigDecimal", () => {
     await Util.expectParseFailure(
       schema,
       BigDecimal.make(-2n, 0),
-      "Expected a non-negative BigDecimal, actual {\"_id\":\"BigDecimal\",\"value\":\"-2\",\"scale\":0}"
+      "Expected a non-negative BigDecimal, actual -2"
     )
     await Util.expectParseSuccess(
       schema,

--- a/test/BigDecimal/nonPositiveBigDecimal.test.ts
+++ b/test/BigDecimal/nonPositiveBigDecimal.test.ts
@@ -15,7 +15,7 @@ describe("BigDecimal/nonPositiveBigDecimal", () => {
     await Util.expectParseFailure(
       schema,
       BigDecimal.make(2n, 0),
-      "Expected a non-positive BigDecimal, actual {\"_id\":\"BigDecimal\",\"value\":\"2\",\"scale\":0}"
+      "Expected a non-positive BigDecimal, actual 2"
     )
     await Util.expectParseSuccess(
       schema,

--- a/test/BigDecimal/positiveBigDecimal.test.ts
+++ b/test/BigDecimal/positiveBigDecimal.test.ts
@@ -10,12 +10,12 @@ describe("BigDecimal/positiveBigDecimal", () => {
     await Util.expectParseFailure(
       schema,
       BigDecimal.make(0n, 0),
-      "Expected a positive BigDecimal, actual {\"_id\":\"BigDecimal\",\"value\":\"0\",\"scale\":0}"
+      "Expected a positive BigDecimal, actual 0"
     )
     await Util.expectParseFailure(
       schema,
       BigDecimal.make(-2n, 0),
-      "Expected a positive BigDecimal, actual {\"_id\":\"BigDecimal\",\"value\":\"-2\",\"scale\":0}"
+      "Expected a positive BigDecimal, actual -2"
     )
     await Util.expectParseSuccess(
       schema,

--- a/test/TreeFormatter.test.ts
+++ b/test/TreeFormatter.test.ts
@@ -99,4 +99,17 @@ describe("formatActual", () => {
     circular.a = circular
     expect(_.formatActual(circular)).toEqual("[object Object]")
   })
+
+  it("should detect data types with a custom `toString` implementation", () => {
+    const noToString = { a: 1 }
+    expect(_.formatActual(noToString)).toEqual(`{"a":1}`)
+    const ToString = Object.create({
+      toString() {
+        return "toString custom implementation"
+      }
+    })
+    expect(_.formatActual(ToString)).toEqual("toString custom implementation")
+    // should not detect arrays
+    expect(_.formatActual([1, 2, 3])).toEqual("[1,2,3]")
+  })
 })


### PR DESCRIPTION
…oString` implementation, closes #600