### PR TITLE
Bug Fix: align index signature behaviour to TypeScript

### DIFF
--- a/.changeset/giant-clocks-compete.md
+++ b/.changeset/giant-clocks-compete.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": minor
+---
+
+Bug Fix: align index signature behaviour to TypeScript

--- a/docs/modules/ParseResult.ts.md
+++ b/docs/modules/ParseResult.ts.md
@@ -155,7 +155,7 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const unexpected: (actual: unknown) => Unexpected
+export declare const unexpected: (ast: Option.Option<AST.AST>) => Unexpected
 ```
 
 Added in v1.0.0
@@ -281,7 +281,7 @@ Error that occurs when an unexpected key or index is present.
 ```ts
 export interface Unexpected {
   readonly _tag: "Unexpected"
-  readonly actual: unknown
+  readonly ast: Option.Option<AST.AST>
 }
 ```
 

--- a/src/ArrayFormatter.ts
+++ b/src/ArrayFormatter.ts
@@ -1,9 +1,10 @@
 /**
  * @since 1.0.0
  */
+import * as Option from "effect/Option"
 import * as ReadonlyArray from "effect/ReadonlyArray"
 import type { ParseErrors } from "./ParseResult.js"
-import { formatActual, getMessage } from "./TreeFormatter.js"
+import { formatExpected, getMessage } from "./TreeFormatter.js"
 
 /**
  * @category model
@@ -31,7 +32,12 @@ const format = (self: ParseErrors, path: ReadonlyArray<PropertyKey> = []): Array
     case "Forbidden":
       return [{ _tag, path, message: "Forbidden" }]
     case "Unexpected":
-      return [{ _tag, path, message: `Unexpected value ${formatActual(self.actual)}` }]
+      return [{
+        _tag,
+        path,
+        message: "Unexpected" +
+          (Option.isSome(self.ast) ? `, expected ${formatExpected(self.ast.value)}` : "")
+      }]
   }
 }
 

--- a/src/ParseResult.ts
+++ b/src/ParseResult.ts
@@ -182,7 +182,7 @@ export const missing: Missing = { _tag: "Missing" }
  */
 export interface Unexpected {
   readonly _tag: "Unexpected"
-  readonly actual: unknown
+  readonly ast: Option.Option<AST.AST>
 }
 
 /**
@@ -190,8 +190,8 @@ export interface Unexpected {
  * @since 1.0.0
  */
 export const unexpected = (
-  actual: unknown
-): Unexpected => ({ _tag: "Unexpected", actual })
+  ast: Option.Option<AST.AST>
+): Unexpected => ({ _tag: "Unexpected", ast })
 
 /**
  * Error that occurs when a member in a union has an error.

--- a/src/TreeFormatter.ts
+++ b/src/TreeFormatter.ts
@@ -162,7 +162,9 @@ const go = (e: ParseErrors): Tree<string> => {
       return make(`[${e.index}]`, es)
     }
     case "Unexpected":
-      return make(`is unexpected`)
+      return make(
+        "is unexpected" + (Option.isSome(e.ast) ? `, expected ${formatExpected(e.ast.value)}` : "")
+      )
     case "Key": {
       const es = e.errors.map(go)
       if (isCollapsible(es, e.errors)) {

--- a/test/ArrayFormatter.test.ts
+++ b/test/ArrayFormatter.test.ts
@@ -72,7 +72,7 @@ describe("ArrayFormatter", () => {
     expectIssues(schema, { a: "a", b: 1 }, [{
       _tag: "Unexpected",
       path: ["b"],
-      message: "Unexpected value 1"
+      message: `Unexpected, expected "a"`
     }])
   })
 
@@ -81,7 +81,7 @@ describe("ArrayFormatter", () => {
     expectIssues(schema, ["a", 1], [{
       _tag: "Unexpected",
       path: [1],
-      message: "Unexpected value 1"
+      message: "Unexpected"
     }])
   })
 
@@ -140,7 +140,7 @@ describe("ArrayFormatter", () => {
       {
         _tag: "Unexpected",
         path: ["a"],
-        message: "Unexpected value 1"
+        message: `Unexpected, expected "age" or "name" or "tags"`
       },
       {
         _tag: "Missing",

--- a/test/Schema/allErrors.test.ts
+++ b/test/Schema/allErrors.test.ts
@@ -82,24 +82,24 @@ describe("Schema/allErrors option", () => {
         await Util.expectParseFailure(
           schema,
           { a: 1, b: "b", c: "c" },
-          `/b is unexpected, /c is unexpected`,
+          `/b is unexpected, expected "a", /c is unexpected, expected "a"`,
           { ...Util.allErrors, ...Util.onExcessPropertyError }
         )
       })
     })
 
     describe("record", () => {
-      it("wrong type for keys", async () => {
+      it("all key errors", async () => {
         const schema = S.record(S.string.pipe(S.minLength(2)), S.number)
         await Util.expectParseFailure(
           schema,
           { a: 1, b: 2 },
-          `/a Expected a string at least 2 character(s) long, actual "a", /b Expected a string at least 2 character(s) long, actual "b"`,
-          Util.allErrors
+          `/a is unexpected, expected a string at least 2 character(s) long, /b is unexpected, expected a string at least 2 character(s) long`,
+          { ...Util.allErrors, ...Util.onExcessPropertyError }
         )
       })
 
-      it("wrong type for values", async () => {
+      it("all value errors", async () => {
         const schema = S.record(S.string, S.number)
         await Util.expectParseFailure(
           schema,
@@ -178,8 +178,8 @@ describe("Schema/allErrors option", () => {
         await Util.expectEncodeFailure(
           schema,
           { aa: "a", bb: "bb" },
-          `/aa Expected a character, actual "aa", /bb Expected a character, actual "bb"`,
-          Util.allErrors
+          `/aa is unexpected, expected a character, /bb is unexpected, expected a character`,
+          { ...Util.allErrors, ...Util.onExcessPropertyError }
         )
       })
 

--- a/test/Schema/is.test.ts
+++ b/test/Schema/is.test.ts
@@ -423,20 +423,39 @@ describe("Schema/is", () => {
     expect(is({ "a-": 1 })).toEqual(true)
     expect(is({ "-b": 1 })).toEqual(true)
     expect(is({ "a-b": 1 })).toEqual(true)
+    expect(is({ "": 1 })).toEqual(true)
+    expect(is({ "a": 1 })).toEqual(true)
+    expect(is({ "a": "a" })).toEqual(true)
 
-    expect(is({ "": 1 })).toEqual(false)
     expect(is({ "-": "a" })).toEqual(false)
+    expect(is({ "a-": "a" })).toEqual(false)
+    expect(is({ "-b": "b" })).toEqual(false)
+    expect(is({ "a-b": "ab" })).toEqual(false)
   })
 
-  it("record(minLength(1), number)", () => {
+  it("record(minLength(2), number)", () => {
     const schema = S.record(S.string.pipe(S.minLength(2)), S.number)
     const is = P.is(schema)
     expect(is({})).toEqual(true)
+    expect(is({ "a": 1 })).toEqual(true)
+    expect(is({ "a": "a" })).toEqual(true)
     expect(is({ "aa": 1 })).toEqual(true)
     expect(is({ "aaa": 1 })).toEqual(true)
 
-    expect(is({ "": 1 })).toEqual(false)
-    expect(is({ "a": 1 })).toEqual(false)
+    expect(is({ "aa": "aa" })).toEqual(false)
+  })
+
+  it("record(${string}-${string}, number) & record(string, string | number)", () => {
+    const schema = S.record(S.templateLiteral(S.string, S.literal("-"), S.string), S.number).pipe(
+      S.extend(S.record(S.string, S.union(S.string, S.number)))
+    )
+    const is = P.is(schema)
+    expect(is({})).toEqual(true)
+    expect(is({ "a": "a" })).toEqual(true)
+    expect(is({ "a-": 1 })).toEqual(true)
+
+    expect(is({ "a-": "a" })).toEqual(false)
+    expect(is({ "a": true })).toEqual(false)
   })
 
   it("union", () => {

--- a/test/Schema/onExcess.test.ts
+++ b/test/Schema/onExcess.test.ts
@@ -26,7 +26,7 @@ describe("Schema/onExcess", () => {
       await Util.expectParseFailure(
         schema,
         { a: 1, b: "b", c: true },
-        `union member: /c is unexpected, union member: /b is unexpected`,
+        `union member: /c is unexpected, expected "a" or "b", union member: /b is unexpected, expected "a"`,
         Util.onExcessPropertyError
       )
       await Util.expectEncodeSuccess(

--- a/test/Schema/struct.test.ts
+++ b/test/Schema/struct.test.ts
@@ -55,7 +55,7 @@ describe("Schema/struct", () => {
       await Util.expectParseFailure(
         schema,
         { a: 1, b: "b" },
-        "/b is unexpected",
+        `/b is unexpected, expected "a"`,
         Util.onExcessPropertyError
       )
     })
@@ -79,7 +79,7 @@ describe("Schema/struct", () => {
       await Util.expectParseFailure(
         schema,
         { a: 1, b: "b" },
-        "/b is unexpected",
+        `/b is unexpected, expected "a"`,
         Util.onExcessPropertyError
       )
     })
@@ -107,7 +107,7 @@ describe("Schema/struct", () => {
       await Util.expectParseFailure(
         schema,
         { a: 1, b: "b" },
-        "/b is unexpected",
+        `/b is unexpected, expected "a"`,
         Util.onExcessPropertyError
       )
     })
@@ -131,7 +131,7 @@ describe("Schema/struct", () => {
       await Util.expectParseFailure(
         schema,
         { a: 1, b: "b" },
-        "/b is unexpected",
+        `/b is unexpected, expected "a"`,
         Util.onExcessPropertyError
       )
     })
@@ -162,7 +162,7 @@ describe("Schema/struct", () => {
       await Util.expectEncodeFailure(
         schema,
         { a: 1, b: "b" } as any,
-        `/b is unexpected`,
+        `/b is unexpected, expected "a"`,
         Util.onExcessPropertyError
       )
     })
@@ -174,7 +174,7 @@ describe("Schema/struct", () => {
       await Util.expectEncodeFailure(
         schema,
         { a: 1, b: "b" } as any,
-        `/b is unexpected`,
+        `/b is unexpected, expected "a"`,
         Util.onExcessPropertyError
       )
     })
@@ -186,7 +186,7 @@ describe("Schema/struct", () => {
       await Util.expectEncodeFailure(
         schema,
         { a: 1, b: "b" } as any,
-        `/b is unexpected`,
+        `/b is unexpected, expected "a"`,
         Util.onExcessPropertyError
       )
     })
@@ -199,7 +199,7 @@ describe("Schema/struct", () => {
       await Util.expectEncodeFailure(
         schema,
         { a: 1, b: "b" } as any,
-        `/b is unexpected`,
+        `/b is unexpected, expected "a"`,
         Util.onExcessPropertyError
       )
     })

--- a/test/TreeFormatter.test.ts
+++ b/test/TreeFormatter.test.ts
@@ -41,7 +41,7 @@ describe("formatErrors", () => {
       { a: "a", b: 1 },
       `error(s) found
 └─ ["b"]
-   └─ is unexpected`,
+   └─ is unexpected, expected "a"`,
       Util.onExcessPropertyError
     )
   })

--- a/test/util.ts
+++ b/test/util.ts
@@ -9,7 +9,7 @@ import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
 import * as Either from "effect/Either"
 import { pipe } from "effect/Function"
-import * as O from "effect/Option"
+import * as Option from "effect/Option"
 import type { NonEmptyReadonlyArray } from "effect/ReadonlyArray"
 import * as RA from "effect/ReadonlyArray"
 import * as fc from "fast-check"
@@ -39,7 +39,7 @@ const effectifyAST = (ast: AST.AST, mode: "all" | "semi"): AST.AST => {
     case "Tuple":
       return AST.createTuple(
         ast.elements.map((e) => AST.createElement(effectifyAST(e.type, mode), e.isOptional)),
-        O.map(ast.rest, RA.map((ast) => effectifyAST(ast, mode))),
+        Option.map(ast.rest, RA.map((ast) => effectifyAST(ast, mode))),
         ast.isReadonly,
         ast.annotations
       )
@@ -264,9 +264,9 @@ const formatDecodeError = (e: PR.ParseErrors): string => {
     case "Type":
       return pipe(
         getMessage(e.expected),
-        O.map((f) => f(e.actual)),
-        O.orElse(() => e.message),
-        O.getOrElse(() =>
+        Option.map((f) => f(e.actual)),
+        Option.orElse(() => e.message),
+        Option.getOrElse(() =>
           `Expected ${formatExpected(e.expected)}, actual ${formatActual(e.actual)}`
         )
       )
@@ -279,7 +279,8 @@ const formatDecodeError = (e: PR.ParseErrors): string => {
     case "Missing":
       return `is missing`
     case "Unexpected":
-      return `is unexpected`
+      return "is unexpected" +
+        (Option.isSome(e.ast) ? `, expected ${formatExpected(e.ast.value)}` : "")
     case "UnionMember":
       return `union member: ${pipe(e.errors, RA.map(formatDecodeError), RA.join(", "))}`
   }


### PR DESCRIPTION
Current behaviour: 

```
for each key in input
  for each index signature
    validate key
    validate value
```

Correct behaviour: 

```
for each key in input
  for each index signature
    if key is valid then validate value
```

RE: https://github.com/gcanti/io-ts/issues/704