### PR TITLE
Attempt at changes in Serializable module

### DIFF
--- a/src/Serializable.ts
+++ b/src/Serializable.ts
@@ -30,7 +30,7 @@ export interface Serializable<I, A> {
  * @category schema
  * @since 1.0.0
  */
-const serializableFromSelf = <I, A extends object>(
+const serializableFromSelf = <I, A>(
   self: Schema.Schema<I, A>
 ): Schema.Schema<I & Serializable<I, A>, A & Serializable<I, A>> =>
   Schema.declare(
@@ -40,7 +40,8 @@ const serializableFromSelf = <I, A extends object>(
       const parse = isDecoding ? Parser.parse(self) : Parser.encode(self)
       return (u, options, ast) => {
         return u !== null && typeof u === "object" && symbol in u ?
-          parse(u, options)
+          ParseResult.map(parse(u, options) as any, (value) =>
+            Object.assign(value as any, { [symbol]: self }))
           : ParseResult.fail(ParseResult.type(ast, u))
       }
     }

--- a/test/Serializable.test.ts
+++ b/test/Serializable.test.ts
@@ -23,6 +23,16 @@ class GetPersonById extends S.Class<GetPersonById>()({
 }
 
 describe("Serializable", () => {
+  test("serializable", () => {
+    const base = S.struct({ id: S.number })
+    const withSerializable = Serializable.serializable(base)
+
+    assert.deepStrictEqual(Effect.runSync(S.decode(withSerializable)({ id: 123 })), {
+      id: 123,
+      [Serializable.symbol]: base
+    })
+  })
+
   test("serialize", () => {
     const req = new GetPersonById({ id: 123 })
     assert.deepStrictEqual(Effect.runSync(Serializable.serialize(req)), {

--- a/test/Serializable.test.ts
+++ b/test/Serializable.test.ts
@@ -23,7 +23,7 @@ class GetPersonById extends S.Class<GetPersonById>()({
 }
 
 describe("Serializable", () => {
-  test("serializable", () => {
+  test("serializable - decode", () => {
     const base = S.struct({ id: S.number })
     const withSerializable = Serializable.serializable(base)
 
@@ -31,6 +31,18 @@ describe("Serializable", () => {
       id: 123,
       [Serializable.symbol]: base
     })
+  })
+
+  test("serializable - encode", () => {
+    const base = S.struct({ id: S.number })
+    const withSerializable = Serializable.serializable(base)
+
+    assert.deepStrictEqual(
+      Effect.runSync(S.encode(withSerializable)({ id: 123, [Serializable.symbol]: base })),
+      {
+        id: 123
+      }
+    )
   })
 
   test("serialize", () => {


### PR DESCRIPTION
Hello everyone!
I attempted, with complete failure, to add some changes to the serializable module, so I wanted to open this PR both as discussion, and as a way to figure out what I am doing wrong.

## Missing schema combinators

I think that we may need few combinators for Schema that we are missing in order to have interop with Serializable.

(1) We need a combinator (the one I attempted here) that does from Schema<I, A> to Schema<I, A & Serializable<I, A>>, which basically just attaches the symbol to the To type.

(2) The second combinator we may need is the same, but for symbolResult, transforming (base: Schema<I, A>) => (failure: Schema<IE, E>, success: Schema<IR, R>) => Schema<I, A & Serializable.WithResult<IE, E, IR, R>.

The third one could be omitted as it would be just performing (1) + (2)

## Keep it simple

All the serializeSuccess, serializeExit etc... APIs are indeed nice, but shall we get into the trouble of having those? Let's say I also want to support Arbitrary. Should we let this module grow just to avoid one additional function call?
Maybe we shold keep this simple and just provide symbols, accessors to schemas inside symbols and that's it. Schema.encode(Serializable.successSchema(value)) is not so bad afterall.

## Recursive definition

Serializable.symbolResult is fine, as it will attach basically a schema for a phantom type, but what about Serializable.symbol?
By looking back at (1) the result of the combinator is recursive by nature. The "A" in Serializable.Serializable<I, A> is basically "this". But "this" definition contains Serializable.symbol again, so we are dealing with recursive land here.

Maybe we should wait for this? I don't see a solution right now that fixes this recursive issue.