### PR TITLE
JSONSchema: Ensure proper handling of identifier annotations when gen…

### DIFF
--- a/.changeset/strong-sheep-march.md
+++ b/.changeset/strong-sheep-march.md
@@ -1,0 +1,5 @@
+---
+"@effect/schema": patch
+---
+
+JSONSchema: Ensure proper handling of identifier annotations when generating a schema through `from()`

--- a/src/JSONSchema.ts
+++ b/src/JSONSchema.ts
@@ -210,12 +210,51 @@ export type JsonSchema7Root = JsonSchema7 & {
  */
 export const to = <I, A>(schema: Schema.Schema<I, A>): JsonSchema7Root => goRoot(AST.to(schema.ast))
 
+const _from = (ast: AST.AST): AST.AST => {
+  switch (ast._tag) {
+    case "Declaration":
+      return AST.createDeclaration(
+        ast.typeParameters.map(_from),
+        _from(ast.type),
+        ast.decode,
+        ast.annotations
+      )
+    case "Tuple":
+      return AST.createTuple(
+        ast.elements.map((e) => AST.createElement(_from(e.type), e.isOptional)),
+        Option.map(ast.rest, ReadonlyArray.map(_from)),
+        ast.isReadonly
+      )
+    case "TypeLiteral":
+      return AST.createTypeLiteral(
+        ast.propertySignatures.map((p) =>
+          AST.createPropertySignature(p.name, _from(p.type), p.isOptional, p.isReadonly)
+        ),
+        ast.indexSignatures.map((is) =>
+          AST.createIndexSignature(is.parameter, _from(is.type), is.isReadonly)
+        )
+      )
+    case "Union":
+      return AST.createUnion(ast.types.map(_from))
+    case "Suspend":
+      return Option.match(AST.getIdentifierAnnotation(ast), {
+        onNone: () => AST.createSuspend(() => _from(ast.f())),
+        onSome: (identifier) =>
+          AST.createSuspend(() => _from(ast.f()), { [AST.IdentifierAnnotationId]: identifier })
+      })
+    case "Refinement":
+    case "Transform":
+      return _from(ast.from)
+  }
+  return ast
+}
+
 /**
  * @category encoding
  * @since 1.0.0
  */
 export const from = <I, A>(schema: Schema.Schema<I, A>): JsonSchema7Root =>
-  goRoot(AST.from(schema.ast))
+  goRoot(_from(schema.ast))
 
 const anyJsonSchema: JsonSchema7 = { $id: "/schemas/any" }
 

--- a/test/JSONSchema.test.ts
+++ b/test/JSONSchema.test.ts
@@ -1270,6 +1270,20 @@ describe("JSONSchema", () => {
       })).toEqual(true)
       propertyTo(Operation, { params: { numRuns: 5 } })
     })
+
+    it("should handle identifier annotations when generating a schema through `from()`", () => {
+      interface Category {
+        readonly name: string
+        readonly categories: ReadonlyArray<Category>
+      }
+
+      const schema: Schema.Schema<Category> = Schema.struct({
+        name: Schema.string,
+        categories: Schema.array(Schema.suspend(() => schema).pipe(Schema.identifier("Category")))
+      })
+      const jsonSchema = JSONSchema.from(schema)
+      console.log(jsonSchema)
+    })
   })
 
   it("Transform should raise an error", () => {


### PR DESCRIPTION
…erating a schema through `from()`, closes #664