### PR TITLE
README: clarify extracting inferred types

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,13 +217,20 @@ interface Person {
 */
 ```
 
-In this example, we use `interface` instead of `type`:
+Alternatively you can also extract a `type` instead of an `interface`:
 
 ```ts
 type Person = S.Schema.To<typeof Person>;
+/*
+Equivalent to:
+type Person {
+  readonly name: string;
+  readonly age: number;
+}
+*/
 ```
 
-to create an opaque type.
+### Advanced extracting Inferred Types
 
 In cases where `I` differs from `A`, you can also extract the inferred `I` type using `Schema.From`.
 


### PR DESCRIPTION
When going through the documentation I was looking for the equivalent of this simple Zod use-case. The way the README was structured regarding extracting inferred types quite confused me.

```ts
import { z } from "zod";

const User = z.object({
  username: z.string(),
});

User.parse({ username: "Ludwig" });

// extract the inferred type
type User = z.infer<typeof User>;
// { username: string }
```

This is an attempt to make it more approachable for newcomers by clearly separating the 99% use-cases from the advanced usage.

