### PR TITLE
README: add email example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2790,6 +2790,20 @@ parse([
 ]); // new Map([[1, "a"], [2, "b"], [3, "c"]])
 ```
 
+# Useful Examples
+
+## Email
+
+Since there are various different definitions of what constitutes a valid email address depending on the environment and use case, `@effect/schema` does not provide a built-in combinator for parsing email addresses. However, it is easy to define a custom combinator that can be used to parse email addresses.
+
+
+```ts
+import * as S from "@effect/schema/Schema";
+
+// see https://stackoverflow.com/questions/46155/how-can-i-validate-an-email-address-in-javascript/46181#46181
+const Email = S.pattern(/^(?!\.)(?!.*\.\.)([A-Z0-9_+-\.]*)[A-Z0-9_+-]@([A-Z0-9][A-Z0-9\-]*\.)+[A-Z]{2,}$/i);
+```
+
 # Technical overview
 
 ## Understanding Schemas


### PR DESCRIPTION
Coming from Zod I felt a bit frustrated that some useful string validations are not available. While I would be concerned adding them to the core I was thinking we can at least make it easy by adding useful examples and developers can decide by themselves if this is for them.

Note I took this one because apparently Zod experimented with it and ended up with this one. Related code here: https://github.com/colinhacks/zod/blob/3e4f71e857e75da722bd7e735b6d657a70682df2/src/types.ts#L555-L568 
